### PR TITLE
Replace plotter class imports with flat function imports

### DIFF
--- a/autolens/plot/__init__.py
+++ b/autolens/plot/__init__.py
@@ -1,6 +1,10 @@
-from autofit.non_linear.plot.nest_plotters import NestPlotter
-from autofit.non_linear.plot.mcmc_plotters import MCMCPlotter
-from autofit.non_linear.plot.mle_plotters import MLEPlotter
+from autofit.non_linear.plot import (
+    corner_cornerpy,
+    corner_anesthetic,
+    subplot_parameters,
+    log_likelihood_vs_iteration,
+    output_figure,
+)
 
 # ---------------------------------------------------------------------------
 # Standalone plot helpers (autoarray)

--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -83,22 +83,20 @@ Create figures and subplots showing quantities of standard **PyAutoLens** object
     subplot_sensitivity
     subplot_sensitivity_figures_of_merit
 
-Non-linear Search Plotters [aplt]
----------------------------------
+Non-linear Search Plot Functions [aplt]
+---------------------------------------
 
-Create figures and subplots of non-linear search specific visualization of every search algorithm supported
-by **PyAutoGalaxy**.
+Module-level functions for visualizing non-linear search results.
 
-.. currentmodule:: autogalaxy.plot
+.. currentmodule:: autofit.plot
 
 .. autosummary::
    :toctree: _autosummary
-   :template: custom-class-template.rst
-   :recursive:
 
-   NestPlotter
-   MCMCPlotter
-   MLEPlotter
+   corner_cornerpy
+   corner_anesthetic
+   subplot_parameters
+   log_likelihood_vs_iteration
 
 Plot Customization [aplt]
 -------------------------


### PR DESCRIPTION
## Summary
Replace imports of removed `NestPlotter`/`MCMCPlotter`/`MLEPlotter` classes in `autolens/plot/__init__.py` with the new module-level functions from PyAutoFit. Update API docs accordingly.

## API Changes
The `autolens.plot` namespace no longer re-exports `NestPlotter`, `MCMCPlotter`, `MLEPlotter`. Instead it exports `corner_cornerpy`, `corner_anesthetic`, `subplot_parameters`, `log_likelihood_vs_iteration`, and `output_figure`.
See full details below.

## Test Plan
- [x] `pytest test_autolens/ -x` — 254 passed

<details>
<summary>📋 Full API Changes (for automation & release notes)</summary>

### Removed
- `autolens.plot.NestPlotter` — was re-exported from `autofit.non_linear.plot.nest_plotters`
- `autolens.plot.MCMCPlotter` — was re-exported from `autofit.non_linear.plot.mcmc_plotters`
- `autolens.plot.MLEPlotter` — was re-exported from `autofit.non_linear.plot.mle_plotters`

### Added
- `autolens.plot.corner_cornerpy` — re-exported from `autofit.non_linear.plot`
- `autolens.plot.corner_anesthetic` — re-exported from `autofit.non_linear.plot`
- `autolens.plot.subplot_parameters` — re-exported from `autofit.non_linear.plot`
- `autolens.plot.log_likelihood_vs_iteration` — re-exported from `autofit.non_linear.plot`
- `autolens.plot.output_figure` — re-exported from `autofit.non_linear.plot`

### Migration
- Before: `import autolens.plot as aplt; plotter = aplt.NestPlotter(samples=s); plotter.corner_anesthetic()`
- After: `import autolens.plot as aplt; aplt.corner_anesthetic(samples=s)`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)