### PR TITLE
Drop Binder URLs, pin Colab URLs to workspace tag 2026.4.13.6

### DIFF
--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -1,0 +1,23 @@
+name: URL Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  url_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          path: repo
+      - name: Checkout PyAutoBuild
+        uses: actions/checkout@v4
+        with:
+          repository: PyAutoLabs/PyAutoBuild
+          ref: main
+          path: PyAutoBuild
+      - name: Run url_check.sh
+        run: bash PyAutoBuild/autobuild/url_check.sh repo

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ PyAutoLens-JAX: Open-Source Strong Lensing
 .. |nbsp| unicode:: 0xA0
     :trim:
 
-.. |binder| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/HEAD
+.. |colab| image:: https://colab.research.google.com/assets/colab-badge.svg
+   :target: https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb
 
 .. |RTD| image:: https://readthedocs.org/projects/pyautolens/badge/?version=latest
     :target: https://pyautolens.readthedocs.io/en/latest/?badge=latest
@@ -38,11 +38,11 @@ PyAutoLens-JAX: Open-Source Strong Lensing
     :target: https://pypi.org/project/autolens/
     :alt: PyPI Version
 
-|binder| |RTD| |Tests| |Build| |code-style| |JOSS| |arXiv|
+|colab| |RTD| |Tests| |Build| |code-style| |JOSS| |arXiv|
 
 `Installation Guide <https://pyautolens.readthedocs.io/en/latest/installation/overview.html>`_ |
 `readthedocs <https://pyautolens.readthedocs.io/en/latest/index.html>`_ |
-`Introduction on Colab <https://colab.research.google.com/github/Jammy2211/autolens_workspace/blob/release/start_here.ipynb>`_ |
+`Introduction on Colab <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb>`_ |
 `HowToLens <https://pyautolens.readthedocs.io/en/latest/howtolens/howtolens.html>`_
 
 .. image:: https://github.com/Jammy2211/PyAutoLogo/blob/main/gifs/pyautolens.gif?raw=true
@@ -59,7 +59,7 @@ The following links are useful for new starters:
 
 - `The PyAutoLens readthedocs <https://pyautolens.readthedocs.io/en/latest>`_: which includes `an overview of PyAutoLens's core features <https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html>`_, `a new user starting guide <https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html>`_ and `an installation guide <https://pyautolens.readthedocs.io/en/latest/installation/overview.html>`_.
 
-- `The introduction Jupyter Notebook on Google Colab <https://colab.research.google.com/github/Jammy2211/autolens_workspace/blob/release/start_here.ipynb>`_: try **PyAutoLens** in a web browser (without installation).
+- `The introduction Jupyter Notebook on Google Colab <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb>`_: try **PyAutoLens** in a web browser (without installation).
 
 - `The autolens_workspace GitHub repository <https://github.com/Jammy2211/autolens_workspace>`_: example scripts and the HowToLens Jupyter notebook lectures.
 

--- a/docs/howtolens/chapter_1_introduction.rst
+++ b/docs/howtolens/chapter_1_introduction.rst
@@ -3,33 +3,33 @@ Chapter 1: Strong Lensing
 
 In chapter 1, we introduce you to strong gravitational lensing and the core **PyAutoLens** API.
 
-**Binder** links to every tutorial are included.
+**Colab** links to every tutorial are included.
 
 The chapter contains the following tutorials:
 
-`Tutorial 0: Visualization <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_0_visualization.ipynb>`_
+`Tutorial 0: Visualization <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_0_visualization.ipynb>`_
 - Setting up **PyAutoLens**'s visualization library.
 
-`Tutorial 1: Grids And Galaxies <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_1_grids_and_galaxies.ipynb>`_
+`Tutorial 1: Grids And Galaxies <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_1_grids_and_galaxies.ipynb>`_
 - Using grids of (y,x) coordinates with galaxies made up of light profiles.
 
-`Tutorial 2: Ray Tracing <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_2_ray_tracing.ipynb>`_
+`Tutorial 2: Ray Tracing <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_2_ray_tracing.ipynb>`_
 - Using grids, galaxies and mass profiles to perform strong lens ray-tracing.
 
-`Tutorial 3: More Ray Tracing <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_3_more_ray_tracing.ipynb>`_
+`Tutorial 3: More Ray Tracing <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_3_more_ray_tracing.ipynb>`_
 - Advanced strong lens ray-tracing.
 
-`Tutorial 4: Point Sources <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_4_point_sources.ipynb>`_
+`Tutorial 4: Point Sources <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_4_point_sources.ipynb>`_
 - How lensing calculations when the source galaxy is a point-source (e.g. a quasar).
 
-`Tutorial 5: Lensing Formalism <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_5_lensing_formalism.ipynb>`_
+`Tutorial 5: Lensing Formalism <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_5_lensing_formalism.ipynb>`_
 - The algebraic lensing formalism used to describe strong lensing.
 
-`Tutorial 6: Data <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_6_data.ipynb>`_
+`Tutorial 6: Data <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_6_data.ipynb>`_
 - Loading and inspecting telescope imaging data of a strong lens.
 
-`Tutorial 7: Fitting <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_7_fitting.ipynb>`_
+`Tutorial 7: Fitting <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_7_fitting.ipynb>`_
 - Fitting data with a strong lens model.
 
-`Tutorial 8: Summary <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_1_introduction/tutorial_8_summary.ipynb>`_
+`Tutorial 8: Summary <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_1_introduction/tutorial_8_summary.ipynb>`_
 - A summary of the chapter.

--- a/docs/howtolens/chapter_2_lens_modeling.rst
+++ b/docs/howtolens/chapter_2_lens_modeling.rst
@@ -5,26 +5,26 @@ In chapter 2, we'll take you through how to model strong lenses using a non-line
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Non-linear Search <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_2_lens_modeling/tutorial_1_non_linear_search.ipynb>`_
+`Tutorial 1: Non-linear Search <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_1_non_linear_search.ipynb>`_
 - How a non-linear search is used to fit a lens model and the concepts of a parameter space and priors.
 
-`Tutorial 2: Practicalities <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_2_lens_modeling/tutorial_2_practicalities.ipynb>`_
+`Tutorial 2: Practicalities <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_2_practicalities.ipynb>`_
 - Practicalities of performing model-fitting, like how to inspect the results on your hard-disk.
 
-`Tutorial 3: Realism and Complexity <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_2_lens_modeling/tutorial_3_realism_and_complexity.ipynb>`_
+`Tutorial 3: Realism and Complexity <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_3_realism_and_complexity.ipynb>`_
 - Finding a balance between realism and complexity when composing and fitting a lens model.
 
-`Tutorial 4: Dealing with Failure <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_2_lens_modeling/tutorial_4_dealing_with_failure.ipynb>`_
+`Tutorial 4: Dealing with Failure <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_4_dealing_with_failure.ipynb>`_
 - What to do when PyAutoLens finds an inaccurate lens model.
 
-`Tutorial 5: Linear Profiles <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_2_lens_modeling/tutorial_5_linear_profiles.ipynb>`_
+`Tutorial 5: Linear Profiles <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_5_linear_profiles.ipynb>`_
 - Light profiles which capture complex morphologies in a reduced number of non-linear parameters.
 
-`Tutorial 6: Masking and Positions <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_2_lens_modeling/tutorial_6_masking_and_positions.ipynb>`_
+`Tutorial 6: Masking and Positions <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_6_masking_and_positions.ipynb>`_
 - How to mask and mark positions on your data to improve the lens model.
 
-`Tutorial 7: Results <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_2_lens_modeling/tutorial_7_results.ipynb>`_
+`Tutorial 7: Results <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_7_results.ipynb>`_
 - Overview of the results available after successfully fitting a lens model.
 
-`Tutorial 8: Need for Speed <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_2_lens_modeling/tutorial_8_need_for_speed.ipynb>`_
+`Tutorial 8: Need for Speed <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_2_lens_modeling/tutorial_8_need_for_speed.ipynb>`_
 - How to fit complex models whilst balancing efficiency and run-time.

--- a/docs/howtolens/chapter_3_search_chaining.rst
+++ b/docs/howtolens/chapter_3_search_chaining.rst
@@ -6,20 +6,20 @@ robust modeling of large strong lens samples.
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Search Chaining <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_3_search_chaining/tutorial_1_search_chaining.ipynb>`_
+`Tutorial 1: Search Chaining <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_1_search_chaining.ipynb>`_
 - Breaking the lens modeling procedure into a chained sequence of model-fits.
 
-`Tutorial 2: Prior Passing <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_3_search_chaining/tutorial_2_prior_passing.ipynb>`_
+`Tutorial 2: Prior Passing <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_2_prior_passing.ipynb>`_
 - How the results of earlier searches are passed to later searches.
 
-`Tutorial 3: Lens and Source <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_3_search_chaining/tutorial_3_lens_and_source.ipynb>`_
+`Tutorial 3: Lens and Source <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_3_lens_and_source.ipynb>`_
 - Fitting the lens's light followed by its mass using chained searches.
 
-`Tutorial 4: Two Lens galaxies <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_3_search_chaining/tutorial_4_x2_lens_galaxies.ipynb>`_
+`Tutorial 4: Two Lens galaxies <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_4_x2_lens_galaxies.ipynb>`_
 - Modeling a strong lens with two lens galaxies using chained searches.
 
-`Tutorial 5: Complex Source <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_3_search_chaining/tutorial_4_complex_source.ipynb>`_
+`Tutorial 5: Complex Source <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_4_complex_source.ipynb>`_
 - Using multiple light profiles to fit a complex and irregular source using chained searches.
 
-`Tutorial 6: SLaM <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_3_search_chaining/tutorial_6_slam.ipynb>`_
+`Tutorial 6: SLaM <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_3_search_chaining/tutorial_6_slam.ipynb>`_
 - Template pipelines for fitting lens model is standardized ways.

--- a/docs/howtolens/chapter_4_pixelizations.rst
+++ b/docs/howtolens/chapter_4_pixelizations.rst
@@ -5,35 +5,35 @@ In chapter 4, we use **Pixelizations** to reconstruct complex source galaxies on
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Pixelizations <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_4_pixelizations/tutorial_1_pixelizations.ipynb>`_
+`Tutorial 1: Pixelizations <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_1_pixelizations.ipynb>`_
 - Creating a pixel-grid in the source-plane.
 
-`Tutorial 2: Mappers <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_4_pixelizations/tutorial_2_mappers.ipynb>`_
+`Tutorial 2: Mappers <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_2_mappers.ipynb>`_
 - How a pixelization maps source-pixels to image-pixels.
 
-`Tutorial 3: Inversions <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_4_pixelizations/tutorial_3_inversions.ipynb>`_
+`Tutorial 3: Inversions <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_3_inversions.ipynb>`_
 - Inverting the mappings to reconstruct the source's light.
 
-`Tutorial 4: Bayesian Regularization <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_4_pixelizations/tutorial_4_bayesian_regularization.ipynb>`_
+`Tutorial 4: Bayesian Regularization <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_4_bayesian_regularization.ipynb>`_
 - Smoothing the source within a Bayesian framework.
 
-`Tutorial 5: Borders <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_4_pixelizations/tutorial_5_borders.ipynb>`_
+`Tutorial 5: Borders <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_5_borders.ipynb>`_
 - Preventing highly demagnified image-pixels ruining the inversion.
 
-`Tutorial 6: Lens Modeling  <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_4_pixelizations/tutorial_6_lens_modeling.ipynb>`_
+`Tutorial 6: Lens Modeling  <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_6_lens_modeling.ipynb>`_
 - How to use inversions to fit a lens model.
 
-`Tutorial 7: Adaptive Pixelization <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_4_pixelizations/tutorial_7_adaptive_pixelization.ipynb>`_
+`Tutorial 7: Adaptive Pixelization <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_7_adaptive_pixelization.ipynb>`_
 - A Voronoi mesh which adapts to the mass model's magnification.
 
-`Tutorial 8: Model Fit <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_4_pixelizations/tutorial_8_model_fit.ipynb>`_
+`Tutorial 8: Model Fit <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_8_model_fit.ipynb>`_
 - An example lens modeling pipeline which uses an inversion.
 
-`Tutorial 9: Fit Problems <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_4_pixelizations/tutorial_9_fit_problems.ipynb>`_
+`Tutorial 9: Fit Problems <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_9_fit_problems.ipynb>`_
 - The shortcomings of our lens models and inversions.
 
-`Tutorial 10: Brightness Adaption <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_4_pixelizations/tutorial_10_brightness_adaption.ipynb>`_
+`Tutorial 10: Brightness Adaption <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_10_brightness_adaption.ipynb>`_
 - Adapting the pixelization to the source's morphology.
 
-`Tutorial 11: Adaptive Regularization <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_4_pixelizations/tutorial_11_adapt_regularization.py.ipynb>`_
+`Tutorial 11: Adaptive Regularization <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_4_pixelizations/tutorial_11_adapt_regularization.py.ipynb>`_
 - Adapting the regularization to the source's morphology.

--- a/docs/howtolens/chapter_optional.rst
+++ b/docs/howtolens/chapter_optional.rst
@@ -5,9 +5,9 @@ This chapter contains optional tutorials expanding on different aspects of how *
 
 The chapter contains the following tutorials:
 
-`Tutorial: Sub-grids  <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_optional/tutorial_sub_grids.ipynb>`_
+`Tutorial: Sub-grids  <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_optional/tutorial_sub_grids.ipynb>`_
 - Use sub-grids to perform more accuratee and precise lensing calculations.
 
-`Tutorial: Searches  <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=notebooks/howtolens/chapter_optional/tutorial_searches.ipynb>`_
+`Tutorial: Searches  <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/howtolens/chapter_optional/tutorial_searches.ipynb>`_
 - Alternative non-linear searches to sample parameter space.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ The following links are useful for new starters:
 
 - `The PyAutoLens readthedocs <https://pyautolens.readthedocs.io/en/latest>`_: which includes `an overview of PyAutoLens's core features <https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html>`_, `a new user starting guide <https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html>`_ and `an installation guide <https://pyautolens.readthedocs.io/en/latest/installation/overview.html>`_.
 
-- `The introduction Jupyter Notebook on Binder <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=start_here.ipynb>`_, where you can try **PyAutoLens** in a web browser (without installation).
+- `The introduction Jupyter Notebook on Colab <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb>`_, where you can try **PyAutoLens** in a web browser (without installation).
 
 - `The autolens_workspace GitHub repository <https://github.com/Jammy2211/autolens_workspace>`_, which includes example scripts and the HowToLens Jupyter notebook lectures.
 

--- a/docs/overview/overview_2_new_user_guide.rst
+++ b/docs/overview/overview_2_new_user_guide.rst
@@ -49,11 +49,11 @@ environment with all the required dependencies already installed.
 This is a great way to get started quickly without needing to install **PyAutoLens** on your own machine,
 so you can check its the right software for you before going through the installation process:
 
- - `imaging/start_here.ipynb <https://colab.research.google.com/github/Jammy2211/autolens_workspace/blob/release/notebooks/imaging/start_here.ipynb>`_: Galaxy scale strong lenses observed with CCD imaging (e.g. Hubble, James Webb).
- - `interferometer/start_here.ipynb <https://colab.research.google.com/github/Jammy2211/autolens_workspace/blob/release/notebooks/interferometer/start_here.ipynb>`_: Galaxy scale strong lenses observed with interferometer data (e.g. ALMA).
- - `point_source/start_here.ipynb <https://colab.research.google.com/github/Jammy2211/autolens_workspace/blob/release/notebooks/point_source/start_here.ipynb>`_: Galaxy scale strong lenses with a lensed point source (e.g. lensed quasars).
- - `group/start_here.ipynb <https://colab.research.google.com/github/Jammy2211/autolens_workspace/blob/release/notebooks/group/start_here.ipynb>`_: Group scale strong lenses where there are 2-10 lens galaxies.
- - `cluster/start_here.ipynb <https://colab.research.google.com/github/Jammy2211/autolens_workspace/blob/release/notebooks/cluster/start_here.ipynb>`_: Cluster scale strong lenses with 2+ lenses and 5+ source galaxies.
+ - `imaging/start_here.ipynb <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/imaging/start_here.ipynb>`_: Galaxy scale strong lenses observed with CCD imaging (e.g. Hubble, James Webb).
+ - `interferometer/start_here.ipynb <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/interferometer/start_here.ipynb>`_: Galaxy scale strong lenses observed with interferometer data (e.g. ALMA).
+ - `point_source/start_here.ipynb <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/point_source/start_here.ipynb>`_: Galaxy scale strong lenses with a lensed point source (e.g. lensed quasars).
+ - `group/start_here.ipynb <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/group/start_here.ipynb>`_: Group scale strong lenses where there are 2-10 lens galaxies.
+ - `cluster/start_here.ipynb <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/notebooks/cluster/start_here.ipynb>`_: Cluster scale strong lenses with 2+ lenses and 5+ source galaxies.
 
 Still Unsure?
 -------------

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -88,7 +88,7 @@ strong lenses. The API allows users to perform ray-tracing by using analytic lig
 lens systems. Accompanying `PyAutoLens` is the [autolens workspace](https://github.com/Jammy2211/autolens_workspace), which 
 includes example scripts, lens datasets and the `HowToLens`
 lectures in Jupyter notebook format which introduce non-experts to strong lensing using `PyAutoLens`. Readers can 
-try `PyAutoLens` right now by going to [the introduction Jupyter notebook on Binder](https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release) 
+try `PyAutoLens` right now by going to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb) 
 or checkout the [readthedocs](https://pyautolens.readthedocs.io/en/latest/) for a complete overview of `PyAutoLens`'s features.
 
 # Background
@@ -181,7 +181,7 @@ contains example scripts for modeling and simulating strong lenses and tutorials
 interferometer datasets before a `PyAutoLens` analysis. Also included are the `HowToLens` tutorials, a five chapter 
 lecture series composed of over 30 Jupyter notebooks aimed at non-experts, introducing them to strong gravitational 
 lensing, Bayesian inference and teaching them how to use `PyAutoLens` for their scientific study. The lectures 
-are available on our [Binder](https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/HEAD) and may therefore be 
+are available on our [Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb) and may therefore be 
 taken without a local `PyAutoLens` installation.
 
 # Software Citations


### PR DESCRIPTION
## Summary

Drop all `mybinder.org` URLs in favour of Google Colab. Pin every Colab URL to the
date-based workspace tag (currently `2026.4.13.6`) so links stay aligned with the
PyPI-released library that users will have installed. Rewrite the GitHub owner
from `Jammy2211` to `PyAutoLabs`.

## What changed

- **URL rewrites** across `*.rst`, `*.md`, `*.ipynb`, `*.py`:
  - `mybinder.org/v2/gh/Jammy2211/<ws>/release?filepath=<path>` → `colab.research.google.com/github/PyAutoLabs/<ws>/blob/2026.4.13.6/<path>`
  - `mybinder.org/v2/gh/Jammy2211/<ws>/HEAD` → `colab.research.google.com/github/PyAutoLabs/<ws>/blob/2026.4.13.6/start_here.ipynb`
  - `colab…/Jammy2211/<ws>/blob/release/<path>` → `colab…/PyAutoLabs/<ws>/blob/2026.4.13.6/<path>`
- **Badge swap**: Binder badge images replaced with the official Colab badge
  (`colab-badge.svg`); RST `|binder|` substitution renamed to `|colab|`.
- **Prose cleanup**: every "Binder" link caption / sentence rewritten to "Colab"
  (case-preserving) so link text matches link target.

## Release-pipeline integration

The release workflow in PyAutoBuild (#49, merged) now invokes
`bump_colab_urls.sh <new-tag>` against this repo on every release, so the pinned
tag advances automatically. No manual maintenance is required after this PR.

## Regression guard

Adds `.github/workflows/url_check.yml` which runs PyAutoBuild's
`autobuild/url_check.sh` on every push and pull request. Re-introducing any
`mybinder.org` URL, `Jammy2211/` Colab owner, or `/blob/release/` Colab ref will
fail CI.

## Test Plan
- [ ] `url_check.yml` workflow passes on this PR
- [ ] Spot-check a Colab URL by clicking through to confirm the notebook loads at the pinned tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
