### PR TITLE
Rewrap point fit data + magnifications for JAX backend parity

### DIFF
--- a/autolens/point/fit/abstract.py
+++ b/autolens/point/fit/abstract.py
@@ -74,6 +74,8 @@ class AbstractFitPoint(aa.AbstractFit, ABC):
         """
 
         self.name = name
+        if xp is not np and data._xp is not xp:
+            data = aa.Grid2DIrregular(values=data.array, xp=xp)
         self._data = data
         self._noise_map = noise_map
         self.tracer = tracer
@@ -131,9 +133,12 @@ class AbstractFitPoint(aa.AbstractFit, ABC):
             use_multi_plane=use_multi_plane,
             plane_j=plane_j,
         )
-        return abs(
-            od.magnification_2d_via_hessian_from(grid=self.positions, xp=self._xp)
+        magnifications = od.magnification_2d_via_hessian_from(
+            grid=self.positions, xp=self._xp
         )
+        if self.use_jax:
+            magnifications = aa.ArrayIrregular(values=magnifications)
+        return abs(magnifications)
 
     @property
     def source_plane_coordinate(self) -> Tuple[float, float]:


### PR DESCRIPTION
## Summary
Two fixes in `AbstractFitPoint` so point-source fits work end-to-end under `use_jax=True`:

1. `__init__` rewraps observed positions (`data`) with the analysis backend when `use_jax=True`. Datasets are loaded as numpy-backed `Grid2DIrregular` from JSON, so without rewrapping the fit's `data._xp` stays `np` even when `xp=jnp` is passed in, and downstream deflection-grid propagation fails.
2. `magnifications_at_positions` rewraps the raw `jax.Array` returned by `LensCalc.magnification_2d_via_hessian_from` (which skips `ArrayIrregular` wrapping on the JAX path) so callers can use `.array` uniformly across backends without hitting `AttributeError` on jax tracers.

Together with PyAutoLabs/PyAutoArray#287, this unblocks full JIT tracing of `FitPositionsSource`.

## Upstream PR
- PyAutoLabs/PyAutoArray#287 — must land first

## API Changes
None — internal changes to `AbstractFitPoint.__init__` and `AbstractFitPoint.magnifications_at_positions`. External behaviour in the numpy path is unchanged; only the JAX path now returns consistent wrapped types and works end-to-end.
See full details below.

## Test Plan
- [x] Full PyAutoLens test suite passes (246 passed)
- [x] `test_autolens/point/fit/` passes (22 passed)
- [x] `autolens_workspace_developer/jax_profiling/point_source/source_plane.py` full pipeline now JITs end-to-end

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
None.

### Added
None.

### Renamed
None.

### Changed Signature
None.

### Changed Behaviour
- `AbstractFitPoint.__init__` — when `xp` is not numpy and the passed `data._xp` does not match, `data` is re-wrapped in a new `Grid2DIrregular` with the requested `xp`. Numpy callers unaffected.
- `AbstractFitPoint.magnifications_at_positions` — on the JAX path the raw `jax.Array` returned by `LensCalc.magnification_2d_via_hessian_from` is now wrapped in `ArrayIrregular` before taking `abs(...)`, so the property consistently returns an `ArrayIrregular` across backends.

### Migration
None — callers that were numpy-backed are unchanged.

</details>

Follows up: PyAutoLabs/PyAutoArray#286

🤖 Generated with [Claude Code](https://claude.com/claude-code)