### PR TITLE
feat: route visualizer fit construction through fit_for_visualization

### DIFF
--- a/autolens/imaging/model/visualizer.py
+++ b/autolens/imaging/model/visualizer.py
@@ -94,7 +94,7 @@ class VisualizerImaging(af.Visualizer):
             An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
             via a non-linear search).
         """
-        fit = analysis.fit_from(instance=instance)
+        fit = analysis.fit_for_visualization(instance=instance)
         tracer = fit.tracer_linear_light_profiles_to_light_profiles
 
         plotter = PlotterImaging(
@@ -236,7 +236,7 @@ class VisualizerImaging(af.Visualizer):
         )
 
         fit_list = [
-            analysis.fit_from(instance=single_instance)
+            analysis.fit_for_visualization(instance=single_instance)
             for analysis, single_instance in zip(analyses, instance)
         ]
 

--- a/autolens/interferometer/model/visualizer.py
+++ b/autolens/interferometer/model/visualizer.py
@@ -93,7 +93,7 @@ class VisualizerInterferometer(af.Visualizer):
             An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
             via a non-linear search).
         """
-        fit = analysis.fit_from(instance=instance)
+        fit = analysis.fit_for_visualization(instance=instance)
         tracer = fit.tracer_linear_light_profiles_to_light_profiles
 
         plotter = PlotterInterferometer(

--- a/autolens/point/model/visualizer.py
+++ b/autolens/point/model/visualizer.py
@@ -64,7 +64,7 @@ class VisualizerPoint(af.Visualizer):
             An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
             via a non-linear search).
         """
-        fit = analysis.fit_from(instance=instance)
+        fit = analysis.fit_for_visualization(instance=instance)
 
         plotter = PlotterPoint(
             image_path=paths.image_path, title_prefix=analysis.title_prefix


### PR DESCRIPTION
## Summary

Swaps `analysis.fit_from(instance=...)` for `analysis.fit_for_visualization(instance=...)` in the imaging, interferometer, and point-source visualizers. This plugs PyAutoLens into the new PyAutoFit dispatch seam added in `PyAutoLabs/PyAutoFit#1228`.

Today the dispatch method is a pass-through to `fit_from`, so runtime behaviour is unchanged — but with `use_jax=True, use_jax_for_visualization=True`, the visualizer now goes through the JAX-aware path that will eventually wrap `fit_from` in `jax.jit` (tracked in `admin_jammy/prompt/autolens/fit_imaging_pytree.md` — requires `FitImaging` pytree registration first).

## API Changes

None — internal changes only. All three visualizers now call `analysis.fit_for_visualization(instance=...)` instead of `analysis.fit_from(instance=...)`; the method they call is new in PyAutoFit and dispatches to `fit_from` today, so end-user behaviour is unchanged.

See full details below.

## Test Plan

- [x] `pytest test_autolens/` full suite — 246 passed
- [ ] `autolens_workspace_test/scripts/imaging/visualization.py` — non-JAX baseline still produces fit.png / tracer.png / inversion plots across all three source types
- [ ] `autolens_workspace_test/scripts/imaging/visualization_jax.py` — new pilot; produces fit.png + tracer.png with `use_jax=True, use_jax_for_visualization=True` on the MGE parametric source

## Dependency

Requires `PyAutoLabs/PyAutoFit#1228` — `Analysis.fit_for_visualization` is introduced there.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour

- `autolens.imaging.model.visualizer.VisualizerImaging` — `visualize` and the rectangular/Delaunay inversion path now call `analysis.fit_for_visualization(instance=...)` instead of `analysis.fit_from(instance=...)`.
- `autolens.interferometer.model.visualizer.VisualizerInterferometer.visualize` — same swap.
- `autolens.point.model.visualizer.VisualizerPoint.visualize` — same swap.

Behaviour is unchanged today (the new method is a pass-through); the swap lets downstream JAX-visualization work plug in at a single seam in PyAutoFit rather than each visualizer.

### Added / Removed / Renamed

None.

### Migration

No migration required for users of `VisualizerImaging` / `VisualizerInterferometer` / `VisualizerPoint`. Custom `Analysis` subclasses that override `fit_from` continue to work unchanged — `fit_for_visualization` dispatches to `fit_from` by default.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)