### PR TITLE
jax: register FitImaging, Tracer, DatasetModel as pytrees on use_jax path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,9 +121,9 @@ The `xp` parameter pattern controls the backend:
 
 ### JAX and the `jax.jit` boundary
 
-Autoarray types (`Array2D`, `ArrayIrregular`, `VectorYX2DIrregular`, etc.) are **not registered as JAX pytrees**. They can be constructed inside a JIT trace, but **cannot be returned** as the output of a `jax.jit`-compiled function.
+Two patterns coexist for crossing the JIT boundary:
 
-Functions intended to be called directly inside `jax.jit` must guard autoarray wrapping with `if xp is np:`:
+**Pattern 1: `if xp is np:` guard (raw `jax.Array` return).** Functions intended to be called directly inside `jax.jit` as the outermost op — where no wrapper is needed on the JAX path — guard their autoarray wrapping:
 
 ```python
 def convergence_2d_via_hessian_from(self, grid, xp=np):
@@ -134,7 +134,9 @@ def convergence_2d_via_hessian_from(self, grid, xp=np):
     return convergence                                  # jax: raw jax.Array
 ```
 
-Functions that are only called as intermediate steps (e.g. `deflections_yx_2d_from`) do not need this guard — they are consumed by downstream Python before the JIT boundary.
+All `LensCalc` hessian-derived methods use this pattern. Intermediate helpers (e.g. `deflections_yx_2d_from`) don't need the guard — they're consumed by downstream Python before the JIT boundary.
+
+**Pattern 2: pytree-registered wrapper return.** Functions that must return a real autoarray wrapper (or a structured object built from them) opt in to JAX pytree registration. `AbstractNDArray` auto-registers its subclass with `jax.tree_util` the first time an instance is built with `xp=jnp` (via `autoarray.abstract_ndarray._register_as_pytree`). Higher-level types (`FitImaging`, `Tracer`, `DatasetModel`) use `autoarray.abstract_ndarray.register_instance_pytree(cls, no_flatten=...)`, which flattens `__dict__` and carries `no_flatten` names through `aux_data` for per-analysis constants (dataset, settings, cosmology). `AnalysisImaging._register_fit_imaging_pytrees` wires these up when `use_jax=True`, so `jax.jit(analysis.fit_from)(instance)` returns a real `FitImaging` with `jax.Array` leaves.
 
 ### `LensCalc` (autogalaxy)
 

--- a/autolens/imaging/model/analysis.py
+++ b/autolens/imaging/model/analysis.py
@@ -108,6 +108,9 @@ class AnalysisImaging(AnalysisDataset):
             The fit of the plane to the imaging dataset, which includes the log likelihood.
         """
 
+        if self._use_jax:
+            self._register_fit_imaging_pytrees()
+
         tracer = self.tracer_via_instance_from(
             instance=instance,
         )
@@ -124,4 +127,26 @@ class AnalysisImaging(AnalysisDataset):
             settings=self.settings,
             xp=self._xp
         )
+
+    @staticmethod
+    def _register_fit_imaging_pytrees() -> None:
+        """Register every type reachable from a ``FitImaging`` return value
+        so ``jax.jit(fit_from)`` can flatten its output.
+
+        ``dataset``, ``adapt_images`` and ``settings`` are constants per
+        analysis — ride as aux so JAX does not recurse into them. Everything
+        else (``tracer``, ``dataset_model`` and the autoarray wrappers they
+        carry) is dynamic per fit.
+        """
+        from autoarray.abstract_ndarray import register_instance_pytree
+        from autoarray.dataset.dataset_model import DatasetModel
+        from autolens.lens.tracer import Tracer
+
+        register_instance_pytree(
+            FitImaging,
+            no_flatten=("dataset", "adapt_images", "settings"),
+        )
+        register_instance_pytree(DatasetModel)
+        # ``cosmology`` is a fixed physical constant per fit; ride as aux.
+        register_instance_pytree(Tracer, no_flatten=("cosmology",))
 


### PR DESCRIPTION
## Summary
Path A for the `fit-imaging-pytree` task (issue #444). `AnalysisImaging.fit_from` now registers `FitImaging`, `Tracer`, and `DatasetModel` as JAX pytree nodes on the first call when `_use_jax` is true. With this in place, `jax.jit(analysis.fit_from)(instance)` returns a real `FitImaging` with `jax.Array` leaves — previously it raised `TypeError: ... is not a valid JAX type` at the JIT output boundary.

`dataset`, `adapt_images`, `settings`, and `cosmology` are pushed through `aux_data` (per-analysis constants, closed over the JIT boundary) via the `no_flatten` option on the generic `register_instance_pytree` helper added in the companion PyAutoArray PR. Only `tracer`, `dataset_model`, and their nested autoarray wrappers flow through as dynamic children.

`CLAUDE.md` is updated: the "autoarray types cannot be returned from `jax.jit`" paragraph now documents two coexisting patterns (the existing `if xp is np:` raw-array guard, and the new pytree-registered wrapper return).

PoC: `autolens_workspace_test/scripts/jax_likelihood_functions/imaging/mge_pytree.py` — `jax.jit(analysis.fit_from)(instance).log_likelihood` matches the NumPy path to ~1e-8 relative error for the MGE parametric lens + MGE source model.

Depends on: https://github.com/PyAutoLabs/PyAutoArray/pull/288

Issue: https://github.com/PyAutoLabs/PyAutoLens/issues/444

## API Changes
One private addition, no public removals/renames:

- New static method `AnalysisImaging._register_fit_imaging_pytrees()` — registers `FitImaging`, `Tracer`, `DatasetModel` as JAX pytree nodes. Called from `fit_from` when `self._use_jax` is true. Idempotent.
- Behavioural change: `jax.jit(analysis.fit_from)(instance)` now succeeds on the JAX path. Previously it raised at the JIT output boundary.

No removals, renames, or public signature changes.

See full details below.

## Test Plan
- [x] `pytest test_autolens/` — 246 passed
- [x] `pytest test_autoarray/` — 736 passed
- [x] `pytest test_autogalaxy/` — 836 passed
- [x] `pytest test_autofit/` — 1232 passed
- [x] MGE PoC: `autolens_workspace_test/scripts/jax_likelihood_functions/imaging/mge_pytree.py` returns `-86629.349379496` under `jax.jit`, matching the NumPy scalar to ~1e-8 rel

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autolens.imaging.model.analysis.AnalysisImaging._register_fit_imaging_pytrees()` (staticmethod) — registers `FitImaging`, `Tracer`, and `DatasetModel` as JAX pytree nodes via the generic `autoarray.abstract_ndarray.register_instance_pytree` helper. `dataset`, `adapt_images`, `settings`, and `cosmology` ride as `aux_data`. Called once at the top of `fit_from` when `self._use_jax` is true. Idempotent.

### Changed Behaviour
- `AnalysisImaging.fit_from(instance)` — when constructed with `use_jax=True`, the returned `FitImaging` can now be returned from a `jax.jit`-compiled function. Previously `jax.jit(analysis.fit_from)(instance)` raised `TypeError: ... FitImaging ... is not a valid JAX type`.

### Migration
None required. Pure NumPy callers see no change. JAX callers who were previously working around the output-boundary error can now return `FitImaging` directly from jit'd code.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)