### PR TITLE
feat: CSV I/O for PointDataset for cluster-scale workflows

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -101,6 +101,8 @@ from .interferometer.fit_interferometer import FitInterferometer
 from .interferometer.model.analysis import AnalysisInterferometer
 from .interferometer.model.visualizer import VisualizerInterferometer
 from .point.dataset import PointDataset
+from .point.dataset import list_from_csv
+from .point.dataset import output_to_csv
 from .point.fit.dataset import FitPointDataset
 from .point.fit.fluxes import FitFluxes
 from .point.fit.times_delays import FitTimeDelays

--- a/autolens/point/dataset.py
+++ b/autolens/point/dataset.py
@@ -6,18 +6,32 @@ as a point (e.g. a quasar, supernova, or compact radio source).  Gravitational l
 splits the source into multiple images whose positions, fluxes, and time delays constrain
 the lens mass distribution.
 
-Two concrete data classes are provided:
+``PointDataset`` holds the image-plane positions, fluxes, and time delays of a single
+named point source together with their noise maps.  The ``name`` attribute is used to
+pair this dataset with the corresponding ``Point`` model component during fitting.
+When multiple point sources are fitted simultaneously (for example many multiply-imaged
+background sources in a strong-lens cluster) they are collected in a plain Python
+``list`` of ``PointDataset`` objects.
 
-- ``PointDataset`` — holds the image-plane positions, fluxes, and time delays of a
-  single named point source together with their noise maps.  The ``name`` attribute is
-  used to pair this dataset with the corresponding ``Point`` model component during
-  fitting.
-- ``PointDict`` — a dictionary of ``PointDataset`` objects keyed by name, used when
-  multiple point sources (e.g. different background quasars) are fitted simultaneously.
+Two I/O surfaces are supported:
+
+- JSON (via :func:`autoconf.output_to_json` / :func:`autoconf.from_json`) — exact
+  round-trip, one file per ``PointDataset``; the canonical modeling input.
+- CSV (via :meth:`PointDataset.to_csv` / :meth:`PointDataset.from_csv` and the
+  module-level :func:`output_to_csv` / :func:`list_from_csv`) — one row per observed
+  image, grouped by ``name``, so that tens or hundreds of cluster-scale point sources
+  can be edited in a single spreadsheet.
 """
+import csv
+from collections import OrderedDict
 from typing import List, Tuple, Optional, Union
 
 import autoarray as aa
+
+
+_BASE_HEADERS = ["name", "y", "x", "positions_noise"]
+_FLUX_HEADERS = ["flux", "flux_noise"]
+_TIME_DELAY_HEADERS = ["time_delay", "time_delay_noise"]
 
 
 class PointDataset:
@@ -121,3 +135,214 @@ class PointDataset:
         x_min = min(self.positions[:, 1]) - buffer
 
         return [y_min, y_max, x_min, x_max]
+
+    def to_csv(self, file_path: str):
+        """
+        Write this dataset to ``file_path`` as a CSV with one row per image.
+
+        Optional flux / time-delay columns are included only when this dataset carries
+        the corresponding values.  For multi-dataset output use :func:`output_to_csv`.
+        """
+        output_to_csv([self], file_path)
+
+    @classmethod
+    def from_csv(
+        cls, file_path: str, name: Optional[str] = None
+    ) -> "PointDataset":
+        """
+        Load a single ``PointDataset`` from a CSV written by :meth:`to_csv` or
+        :func:`output_to_csv`.
+
+        Parameters
+        ----------
+        file_path
+            Path to a CSV file with at minimum the columns
+            ``name, y, x, positions_noise``.
+        name
+            The ``name`` group to load.  Must be provided when the CSV contains more
+            than one ``name``; when the CSV contains exactly one group it is picked
+            automatically.
+        """
+        datasets = list_from_csv(file_path)
+
+        if not datasets:
+            raise ValueError(
+                f"CSV file {file_path!r} contained no PointDataset rows."
+            )
+
+        if name is None:
+            if len(datasets) > 1:
+                available = [d.name for d in datasets]
+                raise ValueError(
+                    f"CSV file {file_path!r} contains {len(datasets)} groups "
+                    f"({available!r}); pass name= to select one."
+                )
+            return datasets[0]
+
+        for dataset in datasets:
+            if dataset.name == name:
+                return dataset
+
+        available = [d.name for d in datasets]
+        raise ValueError(
+            f"CSV file {file_path!r} has no group named {name!r}. "
+            f"Available groups: {available!r}."
+        )
+
+
+def _optional_values(dataset: PointDataset, attr: str) -> Optional[List[float]]:
+    values = getattr(dataset, attr)
+    if values is None:
+        return None
+    return [float(v) for v in values]
+
+
+def output_to_csv(datasets: List[PointDataset], file_path: str):
+    """
+    Write a list of ``PointDataset`` objects to a single CSV with one row per observed
+    image.
+
+    The base columns (``name, y, x, positions_noise``) are always written.  The
+    optional ``flux``/``flux_noise`` and ``time_delay``/``time_delay_noise`` columns
+    are included when *any* dataset in ``datasets`` carries those values; datasets
+    that do not carry them leave those cells blank.
+
+    This is the hand-editable / spreadsheet form preferred for strong-lens cluster
+    workflows with tens or hundreds of multiply-imaged sources.  For exact
+    round-trip serialisation use ``output_to_json`` / ``from_json``.
+    """
+    include_flux = any(d.fluxes is not None for d in datasets)
+    include_time_delay = any(d.time_delays is not None for d in datasets)
+
+    headers = list(_BASE_HEADERS)
+    if include_flux:
+        headers += _FLUX_HEADERS
+    if include_time_delay:
+        headers += _TIME_DELAY_HEADERS
+
+    with open(file_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=headers)
+        writer.writeheader()
+
+        for dataset in datasets:
+            positions = dataset.positions
+            positions_noise = _optional_values(dataset, "positions_noise_map")
+            fluxes = _optional_values(dataset, "fluxes")
+            fluxes_noise = _optional_values(dataset, "fluxes_noise_map")
+            time_delays = _optional_values(dataset, "time_delays")
+            time_delays_noise = _optional_values(dataset, "time_delays_noise_map")
+
+            for i in range(len(positions)):
+                row = {
+                    "name": dataset.name,
+                    "y": float(positions[i][0]),
+                    "x": float(positions[i][1]),
+                    "positions_noise": positions_noise[i],
+                }
+                if include_flux:
+                    row["flux"] = "" if fluxes is None else fluxes[i]
+                    row["flux_noise"] = (
+                        "" if fluxes_noise is None else fluxes_noise[i]
+                    )
+                if include_time_delay:
+                    row["time_delay"] = (
+                        "" if time_delays is None else time_delays[i]
+                    )
+                    row["time_delay_noise"] = (
+                        "" if time_delays_noise is None else time_delays_noise[i]
+                    )
+                writer.writerow(row)
+
+
+def _float_column(
+    group_rows: List[dict], column: str, group_name: str
+) -> Optional[List[float]]:
+    raw = [row.get(column, "") for row in group_rows]
+    populated = [v for v in raw if v not in ("", None)]
+
+    if not populated:
+        return None
+
+    if len(populated) != len(raw):
+        raise ValueError(
+            f"CSV group {group_name!r} has partially populated column "
+            f"{column!r}; every row in the group must have a value or all be blank."
+        )
+
+    return [float(v) for v in raw]
+
+
+def list_from_csv(file_path: str) -> List[PointDataset]:
+    """
+    Load a list of ``PointDataset`` objects from a CSV written by
+    :func:`output_to_csv` (or :meth:`PointDataset.to_csv`).
+
+    Rows are grouped by their ``name`` column — one ``PointDataset`` per distinct
+    name, preserving the order of first appearance.  Optional columns
+    (``flux``/``flux_noise``, ``time_delay``/``time_delay_noise``) are carried through
+    per-group: if every row in a group populates the column the values are loaded,
+    if every row leaves it blank the corresponding attribute is set to ``None``, and
+    any partial-population is rejected with a ``ValueError``.
+    """
+    with open(file_path, newline="") as f:
+        reader = csv.DictReader(f)
+        headers = reader.fieldnames or []
+        rows = list(reader)
+
+    for required in _BASE_HEADERS:
+        if required not in headers:
+            raise ValueError(
+                f"CSV file {file_path!r} is missing required column {required!r}; "
+                f"expected headers starting with {_BASE_HEADERS!r}."
+            )
+
+    groups: "OrderedDict[str, List[dict]]" = OrderedDict()
+    for row in rows:
+        groups.setdefault(row["name"], []).append(row)
+
+    has_flux_column = "flux" in headers
+    has_flux_noise_column = "flux_noise" in headers
+    has_time_delay_column = "time_delay" in headers
+    has_time_delay_noise_column = "time_delay_noise" in headers
+
+    datasets: List[PointDataset] = []
+    for name, group_rows in groups.items():
+        positions = [(float(r["y"]), float(r["x"])) for r in group_rows]
+        positions_noise_map = [
+            float(r["positions_noise"]) for r in group_rows
+        ]
+
+        fluxes = (
+            _float_column(group_rows, "flux", name)
+            if has_flux_column
+            else None
+        )
+        fluxes_noise_map = (
+            _float_column(group_rows, "flux_noise", name)
+            if has_flux_noise_column
+            else None
+        )
+        time_delays = (
+            _float_column(group_rows, "time_delay", name)
+            if has_time_delay_column
+            else None
+        )
+        time_delays_noise_map = (
+            _float_column(group_rows, "time_delay_noise", name)
+            if has_time_delay_noise_column
+            else None
+        )
+
+        datasets.append(
+            PointDataset(
+                name=name,
+                positions=positions,
+                positions_noise_map=positions_noise_map,
+                fluxes=fluxes,
+                fluxes_noise_map=fluxes_noise_map,
+                time_delays=time_delays,
+                time_delays_noise_map=time_delays_noise_map,
+            )
+        )
+
+    return datasets

--- a/test_autolens/point/test_dataset.py
+++ b/test_autolens/point/test_dataset.py
@@ -1,0 +1,157 @@
+import os
+
+import pytest
+
+import autolens as al
+
+
+def _assert_grid_close(actual, expected):
+    actual_pairs = [(float(p[0]), float(p[1])) for p in actual]
+    expected_pairs = [(float(p[0]), float(p[1])) for p in expected]
+    assert actual_pairs == pytest.approx(expected_pairs)
+
+
+def _assert_array_close(actual, expected):
+    if expected is None:
+        assert actual is None
+        return
+    assert actual is not None
+    assert [float(v) for v in actual] == pytest.approx(
+        [float(v) for v in expected]
+    )
+
+
+def _assert_dataset_equal(actual: al.PointDataset, expected: al.PointDataset):
+    assert actual.name == expected.name
+    _assert_grid_close(actual.positions, expected.positions)
+    _assert_array_close(actual.positions_noise_map, expected.positions_noise_map)
+    _assert_array_close(actual.fluxes, expected.fluxes)
+    _assert_array_close(actual.fluxes_noise_map, expected.fluxes_noise_map)
+    _assert_array_close(actual.time_delays, expected.time_delays)
+    _assert_array_close(actual.time_delays_noise_map, expected.time_delays_noise_map)
+
+
+def test__csv_round_trip__positions_only(tmp_path):
+    dataset = al.PointDataset(
+        name="source_0",
+        positions=[(0.5, 1.0), (-0.25, 2.0), (1.5, -1.0)],
+        positions_noise_map=[0.05, 0.05, 0.1],
+    )
+
+    file_path = os.path.join(tmp_path, "point_dataset.csv")
+    dataset.to_csv(file_path)
+
+    loaded = al.PointDataset.from_csv(file_path)
+
+    _assert_dataset_equal(loaded, dataset)
+    assert loaded.fluxes is None
+    assert loaded.fluxes_noise_map is None
+    assert loaded.time_delays is None
+    assert loaded.time_delays_noise_map is None
+
+
+def test__csv_round_trip__positions_and_fluxes(tmp_path):
+    dataset = al.PointDataset(
+        name="source_0",
+        positions=[(0.0, 0.0), (1.0, 1.0)],
+        positions_noise_map=[0.05, 0.05],
+        fluxes=[1.2, 0.8],
+        fluxes_noise_map=[0.1, 0.15],
+    )
+
+    file_path = os.path.join(tmp_path, "point_dataset.csv")
+    dataset.to_csv(file_path)
+
+    loaded = al.PointDataset.from_csv(file_path)
+
+    _assert_dataset_equal(loaded, dataset)
+    assert loaded.time_delays is None
+    assert loaded.time_delays_noise_map is None
+
+
+def test__csv_round_trip__positions_and_time_delays(tmp_path):
+    dataset = al.PointDataset(
+        name="source_0",
+        positions=[(0.0, 0.0), (1.0, 1.0)],
+        positions_noise_map=[0.05, 0.05],
+        time_delays=[10.0, 25.0],
+        time_delays_noise_map=[1.0, 2.5],
+    )
+
+    file_path = os.path.join(tmp_path, "point_dataset.csv")
+    dataset.to_csv(file_path)
+
+    loaded = al.PointDataset.from_csv(file_path)
+
+    _assert_dataset_equal(loaded, dataset)
+    assert loaded.fluxes is None
+    assert loaded.fluxes_noise_map is None
+
+
+def test__csv_round_trip__positions_fluxes_and_time_delays(tmp_path):
+    dataset = al.PointDataset(
+        name="source_0",
+        positions=[(0.0, 0.0), (1.0, 1.0), (-1.5, 0.5)],
+        positions_noise_map=[0.05, 0.05, 0.08],
+        fluxes=[1.2, 0.8, 0.5],
+        fluxes_noise_map=[0.1, 0.15, 0.12],
+        time_delays=[10.0, 25.0, 40.0],
+        time_delays_noise_map=[1.0, 2.5, 3.0],
+    )
+
+    file_path = os.path.join(tmp_path, "point_dataset.csv")
+    dataset.to_csv(file_path)
+
+    loaded = al.PointDataset.from_csv(file_path)
+
+    _assert_dataset_equal(loaded, dataset)
+
+
+def test__csv_list_round_trip__heterogeneous_optional_columns(tmp_path):
+    with_fluxes = al.PointDataset(
+        name="source_0",
+        positions=[(0.0, 0.0), (1.0, 1.0)],
+        positions_noise_map=[0.05, 0.05],
+        fluxes=[1.2, 0.8],
+        fluxes_noise_map=[0.1, 0.15],
+    )
+    positions_only = al.PointDataset(
+        name="source_1",
+        positions=[(2.0, 0.5), (-1.0, 0.5)],
+        positions_noise_map=[0.1, 0.1],
+    )
+
+    file_path = os.path.join(tmp_path, "point_datasets.csv")
+    al.output_to_csv([with_fluxes, positions_only], file_path)
+
+    loaded = al.list_from_csv(file_path)
+
+    assert [d.name for d in loaded] == ["source_0", "source_1"]
+    _assert_dataset_equal(loaded[0], with_fluxes)
+    _assert_dataset_equal(loaded[1], positions_only)
+    assert loaded[1].fluxes is None
+    assert loaded[1].fluxes_noise_map is None
+
+
+def test__from_csv__multiple_groups_requires_name(tmp_path):
+    datasets = [
+        al.PointDataset(
+            name="source_0",
+            positions=[(0.0, 0.0)],
+            positions_noise_map=[0.05],
+        ),
+        al.PointDataset(
+            name="source_1",
+            positions=[(1.0, 1.0)],
+            positions_noise_map=[0.05],
+        ),
+    ]
+
+    file_path = os.path.join(tmp_path, "point_datasets.csv")
+    al.output_to_csv(datasets, file_path)
+
+    with pytest.raises(ValueError):
+        al.PointDataset.from_csv(file_path)
+
+    picked = al.PointDataset.from_csv(file_path, name="source_1")
+    assert picked.name == "source_1"


### PR DESCRIPTION
## Summary

Strong-lens cluster workflows can involve tens or hundreds of multiply-imaged
background sources.  Editing that many per-source JSON files by hand is
unwieldy — one row per image grouped by `name` in a spreadsheet is a much
better hand-editing surface.

This PR adds a CSV I/O path for `PointDataset` alongside the existing JSON
path.  JSON remains the canonical exact-round-trip format used by the
modeling scripts; CSV is the hand-editable cluster form.  No new runtime
dependencies — `csv` stdlib only, no `pandas`.

Closes #446.

## API Changes

- **Added**: `PointDataset.to_csv(file_path)`, classmethod
  `PointDataset.from_csv(file_path, name=None)`, and module-level
  `autolens.output_to_csv(datasets, file_path)` /
  `autolens.list_from_csv(file_path)` — CSV I/O, one row per observed image,
  grouped by `name`; optional `flux` / `time_delay` column groups dropped
  when blank for every row.
- **Docstring fix**: drop the stale `PointDict` bullet in
  `autolens/point/dataset.py` module docstring (that class no longer
  exists); document the JSON-vs-CSV surfaces instead.
- No removals, renames, or signature changes.  Purely additive.

See full details below.

## Test Plan

- [x] `test_autolens/point/test_dataset.py` — round-trip tests for:
  - positions-only
  - positions + fluxes + fluxes_noise_map
  - positions + time_delays + time_delays_noise_map
  - all optional fields populated
  - heterogeneous list (one dataset with fluxes, one without) — exercises
    optional-column handling at the list level
  - multi-group `from_csv` requires explicit `name=`, single-group
    auto-picks
- [x] Module-level manual round-trip of every case (pytest couldn't load in
  the sandbox: installed `autogalaxy` predates `LensCalc`, the conftest
  import fails before collection — not an issue with the new code).
- [ ] CI / maintainer-side `pytest test_autolens/point/test_dataset.py`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autolens.PointDataset.to_csv(file_path: str) -> None` — write a single
  dataset as one CSV, one row per observed image.
- `classmethod autolens.PointDataset.from_csv(file_path: str, name: Optional[str] = None) -> PointDataset`
  — load a single dataset; `name=` required when the CSV has multiple
  groups, auto-picked when it has exactly one.
- `autolens.output_to_csv(datasets: List[PointDataset], file_path: str) -> None`
  — write a list of datasets to a single CSV; optional flux / time-delay
  column groups are included when *any* dataset carries those values and
  left blank for datasets that do not.
- `autolens.list_from_csv(file_path: str) -> List[PointDataset]` — load a
  list of datasets grouped by the `name` column in order of first
  appearance; raises `ValueError` on partially-populated optional columns
  within a group.

### CSV schema (one row per image)

| name | y | x | positions_noise | flux | flux_noise | time_delay | time_delay_noise |

- `name, y, x, positions_noise` always written.
- `flux, flux_noise` added iff any dataset has `fluxes`.
- `time_delay, time_delay_noise` added iff any dataset has `time_delays`.

### Changed Behaviour
- None for existing code paths.

### Removed
- None.

### Renamed
- None.

### Migration
- No migration needed — JSON paths (`output_to_json` / `from_json`) are
  untouched and remain the canonical modeling input.  CSV is opt-in for
  cluster-scale hand-editing workflows.

### Non-goals (explicitly deferred to follow-up issues)
- `FitPointDataset.to_csv` residual / chi-squared export.
- Introducing a `PointDatasetList` class (list-level helpers stay as plain
  functions for now).
- Adding `pandas` as a dependency.
- Promoting CSV I/O to `autoconf` alongside `fits` / `json` (discussed with
  @Jammy2211 — reasonable future cleanup, but out of scope here).

</details>

https://claude.ai/code/session_01WUVZQGGLQhVKcprvUMf1Sa