### PR TITLE
fix: off-by-one in test__lp_linear_func_galaxy_dict_from exposed by LightProfileLinear eq

### DIFF
--- a/test_autolens/lens/test_to_inversion.py
+++ b/test_autolens/lens/test_to_inversion.py
@@ -109,8 +109,8 @@ def test__lp_linear_func_galaxy_dict_from(masked_imaging_7x7):
 
     assert lp_linear_func_list[0].light_profile_list[0] == lp_linear_0
     assert lp_linear_func_list[0].light_profile_list[1] == lp_linear_1
-    assert lp_linear_func_list[1].light_profile_list[0] == lp_linear_3
-    assert lp_linear_func_list[2].light_profile_list[0] == lp_linear_4
+    assert lp_linear_func_list[1].light_profile_list[0] == lp_linear_2
+    assert lp_linear_func_list[2].light_profile_list[0] == lp_linear_3
 
 
 def test__cls_pg_list_from(masked_imaging_7x7, grid_2d_7x7):


### PR DESCRIPTION
## Summary

Fixes a pre-existing off-by-one bug in `test__lp_linear_func_galaxy_dict_from` that was hidden by the old structural `__dict__`-based `__eq__` on `LightProfileLinear`. The companion PyAutoGalaxy PR introduces token-based `__eq__` on `LightProfileLinear` which exposes the bug — without this fix the test suite goes red under that change.

The test sets up `galaxy_linear_2` with `lp_linear_2` and `galaxy_linear_3`'s basis with `[lp_linear_3, lp_linear_4]`, but asserted `lp_linear_3` and `lp_linear_4` at positions that should reference `lp_linear_2` and `lp_linear_3`. Structural eq on parameter-less `LightProfileLinear()` instances made the wrong assertions pass.

Companion PR: PyAutoLabs/PyAutoGalaxy#360

## API Changes

None — internal test-only fix.

See full details below.

## Test Plan
- [x] PyAutoLens test suite: 252 passed (against the PyAutoGalaxy companion PR)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- None.

### Migration
- None.

</details>

Closes PyAutoLabs/PyAutoLens#448