### PR TITLE
register FitPointDataset pytrees for jit(fit_from)

### DIFF
--- a/autolens/point/model/analysis.py
+++ b/autolens/point/model/analysis.py
@@ -151,6 +151,10 @@ class AnalysisPoint(AgAnalysis, AnalysisLens):
         -------
         The fit of the lens model to the point source dataset.
         """
+
+        if self._use_jax:
+            self._register_fit_point_pytrees()
+
         tracer = self.tracer_via_instance_from(
             instance=instance,
         )
@@ -162,6 +166,45 @@ class AnalysisPoint(AgAnalysis, AnalysisLens):
             fit_positions_cls=self.fit_positions_cls,
             xp=self._xp,
         )
+
+    @staticmethod
+    def _register_fit_point_pytrees() -> None:
+        """Register every type reachable from a ``FitPointDataset`` return value
+        so ``jax.jit(fit_from)`` can flatten its output.
+
+        ``dataset`` and ``solver`` are constants per analysis — ride as aux so
+        JAX does not recurse into them. ``fit_positions_cls`` is a class reference
+        (not a value) so must also ride as aux. ``tracer`` is dynamic per fit.
+        """
+        from autoarray.abstract_ndarray import register_instance_pytree
+        from autolens.lens.tracer import Tracer
+        from autolens.point.fit.positions.image.pair_all import FitPositionsImagePairAll
+        from autolens.point.fit.positions.image.pair_repeat import FitPositionsImagePairRepeat
+        from autolens.point.fit.positions.image.pair import FitPositionsImagePair
+        import autogalaxy as ag
+
+        register_instance_pytree(
+            FitPointDataset,
+            no_flatten=("dataset", "solver", "fit_positions_cls"),
+        )
+        register_instance_pytree(Tracer, no_flatten=("cosmology",))
+        # fit-point-pytree: observed data/noise are per-analysis constants; solver/name/use_jax are non-JAX
+        register_instance_pytree(
+            FitPositionsImagePairAll,
+            no_flatten=("solver", "name", "use_jax", "_data", "_noise_map"),
+        )
+        # fit-point-pytree
+        register_instance_pytree(
+            FitPositionsImagePairRepeat,
+            no_flatten=("solver", "name", "use_jax", "_data", "_noise_map"),
+        )
+        # fit-point-pytree
+        register_instance_pytree(
+            FitPositionsImagePair,
+            no_flatten=("solver", "name", "use_jax", "_data", "_noise_map"),
+        )
+        # fit-point-pytree: ag.ps.Point / PointFlux are handled by
+        # autofit.jax.pytrees.register_model before jit is called; skip here.
 
     def save_attributes(self, paths: af.DirectoryPaths):
         """


### PR DESCRIPTION
## Summary
Enable `jax.jit(analysis.fit_from)(instance)` for `AnalysisPoint` so the returned `FitPointDataset` has a traced `jax.Array` `log_likelihood` matching the NumPy-path scalar — completing the point-source entry in the pytree PoC series.

## API Changes
Adds a private `_register_fit_point_pytrees` classmethod on `AnalysisPoint` that registers `FitPointDataset`, `Tracer`, and the three `FitPositions*` classes as JAX pytrees. Called once from `fit_from` when `use_jax=True`. No public surface change.
See full details below.

## Test Plan
- [x] `python -m pytest test_autolens/point/ -x -q` — 44 passed
- [x] `python -m pytest test_autolens/analysis/ test_autolens/lens/ -x -q` — 113 passed
- [x] `autolens_workspace_test/scripts/jax_likelihood_functions/point_source/point_pytree.py` passes round-trip

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autolens.point.model.analysis.AnalysisPoint._register_fit_point_pytrees()` — classmethod; idempotent. Registers:
  - `FitPointDataset` — `no_flatten=("dataset", "solver", "fit_positions_cls")`
  - `Tracer` — `no_flatten=("cosmology",)`
  - `FitPositionsImagePairAll` — `no_flatten=("solver", "name", "use_jax", "_data", "_noise_map")`
  - `FitPositionsImagePairRepeat` — same `no_flatten`
  - `FitPositionsImagePair` — same `no_flatten`

### Changed Behaviour
- `AnalysisPoint.fit_from(instance)` now calls `_register_fit_point_pytrees()` once when `self._use_jax` is `True`, enabling the returned `FitPointDataset` to be traced through `jax.jit`.

### Notes
- `ps.Point` / `ps.PointFlux` are not registered here — `autofit.jax.pytrees.register_model(model)` already handles them and would duplicate-register if called a second time.
- `_data` / `_noise_map` ride as aux because the observed positions come from the on-disk `PointDataset` and are per-analysis constants.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)