### PR TITLE
refactor(point): make PointSolver stateless w.r.t. xp

### DIFF
--- a/autolens/analysis/result.py
+++ b/autolens/analysis/result.py
@@ -104,7 +104,7 @@ class Result(AgResultDataset):
         grid = self.analysis.dataset.mask.derive_grid.all_false
 
         solver = PointSolver.for_grid(
-            grid=grid, pixel_scale_precision=0.001, xp=self.analysis._xp
+            grid=grid, pixel_scale_precision=0.001
         )
 
         source_plane_centre = self.source_plane_centre_from(
@@ -114,6 +114,7 @@ class Result(AgResultDataset):
         multiple_images = solver.solve(
             tracer=self.max_log_likelihood_tracer,
             source_plane_coordinate=source_plane_centre.in_list[0],
+            xp=self.analysis._xp,
             plane_redshift=plane_redshift,
         )
 
@@ -166,7 +167,7 @@ class Result(AgResultDataset):
         centre = self.source_plane_centre_from(plane_redshift=plane_redshift).in_list[0]
 
         solver = PointSolver.for_grid(
-            grid=grid, pixel_scale_precision=0.001, xp=self.analysis._xp
+            grid=grid, pixel_scale_precision=0.001
         )
 
         for i in range(1, increments):
@@ -175,6 +176,7 @@ class Result(AgResultDataset):
             multiple_images = solver.solve(
                 tracer=self.max_log_likelihood_tracer,
                 source_plane_coordinate=(centre[0] * factor, centre[1] * factor),
+                xp=self.analysis._xp,
                 plane_redshift=plane_redshift,
             )
 

--- a/autolens/point/fit/positions/image/abstract.py
+++ b/autolens/point/fit/positions/image/abstract.py
@@ -120,6 +120,7 @@ class AbstractFitPositionsImagePair(AbstractFitPositions, ABC):
         return self.solver.solve(
             tracer=self.tracer,
             source_plane_coordinate=self.source_plane_coordinate,
+            xp=self._xp,
             plane_redshift=self.plane_redshift,
             remove_infinities=False,
         )

--- a/autolens/point/mock/mock_solver.py
+++ b/autolens/point/mock/mock_solver.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+import numpy as np
+
 
 class MockPointSolver:
     def __init__(self, model_positions):
@@ -9,6 +11,7 @@ class MockPointSolver:
         self,
         tracer,
         source_plane_coordinate,
+        xp=np,
         plane_redshift: Optional[float] = None,
         remove_infinities: bool = True,
     ):

--- a/autolens/point/solver/point_solver.py
+++ b/autolens/point/solver/point_solver.py
@@ -36,6 +36,7 @@ class PointSolver(AbstractSolver):
         self,
         tracer: Tracer,
         source_plane_coordinate: Tuple[float, float],
+        xp=np,
         plane_redshift: Optional[float] = None,
         remove_infinities: bool = True,
     ) -> aa.Grid2DIrregular:
@@ -57,11 +58,14 @@ class PointSolver(AbstractSolver):
 
         Parameters
         ----------
+        tracer
+            The tracer that traces the image plane coordinates to the source plane.
         source_plane_coordinate
             The plane coordinate to trace to the image plane, which by default in the source-plane coordinate
             but could be a coordinate in another plane is `plane_redshift` is input.
-        tracer
-            The tracer that traces the image plane coordinates to the source plane
+        xp
+            The array module (``numpy`` or ``jax.numpy``) the solve runs in. ``AnalysisPoint``
+            passes ``jax.numpy`` when ``use_jax=True`` is set on the analysis.
         plane_redshift
             The redshift of the plane coordinate, which for multi-plane systems may not be the source-plane.
 
@@ -73,23 +77,24 @@ class PointSolver(AbstractSolver):
         kept_triangles = super().solve_triangles(
             tracer=tracer,
             shape=Point(*source_plane_coordinate),
+            xp=xp,
             plane_redshift=plane_redshift,
         )
 
         filtered_means = self._filter_low_magnification(
-            tracer=tracer, points=kept_triangles.means
+            tracer=tracer, points=kept_triangles.means, xp=xp
         )
 
         solution = aa.Grid2DIrregular(
-            [pair for pair in filtered_means], xp=self._xp
+            [pair for pair in filtered_means], xp=xp
         ).array
 
-        is_nan = self._xp.isnan(solution).any(axis=1)
-        sentinel = self._xp.full_like(solution[0], fill_value=self._xp.inf)
-        solution = self._xp.where(is_nan[:, None], sentinel, solution)
+        is_nan = xp.isnan(solution).any(axis=1)
+        sentinel = xp.full_like(solution[0], fill_value=xp.inf)
+        solution = xp.where(is_nan[:, None], sentinel, solution)
 
         if remove_infinities:
 
-            solution = solution[~self._xp.isinf(solution).any(axis=1)]
+            solution = solution[~xp.isinf(solution).any(axis=1)]
 
         return aa.Grid2DIrregular(solution)

--- a/autolens/point/solver/shape_solver.py
+++ b/autolens/point/solver/shape_solver.py
@@ -34,44 +34,70 @@ class AbstractSolver:
     # noinspection PyPep8Naming
     def __init__(
         self,
+        y_min: float,
+        y_max: float,
+        x_min: float,
+        x_max: float,
         scale: float,
-        initial_triangles,
         pixel_scale_precision: float,
         magnification_threshold=0.1,
         neighbor_degree: int = 1,
-        xp=np,
     ):
         """
         Determine the image plane coordinates that are traced to be a source plane coordinate.
 
         This is performed efficiently by iteratively subdividing the image plane into triangles and checking if the
         source plane coordinate is contained within the triangle. The triangles are subsampled to increase the
-        resolution
+        resolution.
+
+        The solver is stateless with respect to the array module (``xp``); the array
+        module is chosen per ``.solve()`` call and the initial triangle tiling is
+        built lazily from the stored geometry primitives.
 
         Parameters
         ----------
+        y_min, y_max, x_min, x_max
+            The extent of the image plane used to tile the initial triangles.
+        scale
+            The pixel scale of the image plane. The initial triangles have this side length.
+        pixel_scale_precision
+            The target pixel scale of the image grid.
+        magnification_threshold
+            The threshold for the magnification under which multiple images are filtered.
         neighbor_degree
             The number of times recursively add neighbors for the triangles that contain
             the source plane coordinate.
-        pixel_scale_precision
-            The target pixel scale of the image grid.
         """
+        self.y_min = y_min
+        self.y_max = y_max
+        self.x_min = x_min
+        self.x_max = x_max
         self.scale = scale
         self.pixel_scale_precision = pixel_scale_precision
         self.magnification_threshold = magnification_threshold
         self.neighbor_degree = neighbor_degree
 
-        self.initial_triangles = initial_triangles
+    def _initial_triangles(self, xp):
+        """
+        Build the initial triangle tiling for the stored image-plane extent, using
+        the JAX or NumPy triangle implementation depending on ``xp``.
+        """
+        if xp.__name__.startswith("jax"):
+            from autoarray.structures.triangles.coordinate_array import (
+                CoordinateArrayTriangles as triangle_cls,
+            )
+        else:
+            from autoarray.structures.triangles.coordinate_array_np import (
+                CoordinateArrayTrianglesNp as triangle_cls,
+            )
 
-        self.use_jax = xp is not np
-
-    @property
-    def _xp(self):
-        if self.use_jax:
-            import jax.numpy as jnp
-
-            return jnp
-        return np
+        return triangle_cls.for_limits_and_scale(
+            y_min=self.y_min,
+            y_max=self.y_max,
+            x_min=self.x_min,
+            x_max=self.x_max,
+            scale=self.scale,
+        )
 
     # noinspection PyPep8Naming
     @classmethod
@@ -81,7 +107,6 @@ class AbstractSolver:
         pixel_scale_precision: float,
         magnification_threshold=0.1,
         neighbor_degree: int = 1,
-        xp=np,
     ):
         """
         Create a solver for a given grid.
@@ -96,9 +121,6 @@ class AbstractSolver:
             The precision to which the triangles should be subdivided.
         magnification_threshold
             The threshold for the magnification under which multiple images are filtered.
-        max_containing_size
-            Only applies to JAX. This is the maximum number of multiple images expected.
-            We need to know this in advance to allocate memory for the JAX array.
         neighbor_degree
             The number of times recursively add neighbors for the triangles that contain
 
@@ -111,21 +133,15 @@ class AbstractSolver:
         y = grid[:, 0]
         x = grid[:, 1]
 
-        y_min = y.min()
-        y_max = y.max()
-        x_min = x.min()
-        x_max = x.max()
-
         return cls.for_limits_and_scale(
-            y_min=y_min,
-            y_max=y_max,
-            x_min=x_min,
-            x_max=x_max,
+            y_min=y.min(),
+            y_max=y.max(),
+            x_min=x.min(),
+            x_max=x.max(),
             scale=scale,
             pixel_scale_precision=pixel_scale_precision,
             magnification_threshold=magnification_threshold,
             neighbor_degree=neighbor_degree,
-            xp=xp,
         )
 
     @classmethod
@@ -139,19 +155,13 @@ class AbstractSolver:
         pixel_scale_precision: float = 0.001,
         magnification_threshold=0.1,
         neighbor_degree: int = 1,
-        xp=np,
     ):
         """
-        Create a solver for a given grid.
-
-        The grid defines the limits of the image plane and the pixel scale.
+        Create a solver for an explicit image-plane extent.
 
         Parameters
         ----------
-        y_min
-        y_max
-        x_min
-        x_max
+        y_min, y_max, x_min, x_max
             The limits of the image plane in pixels.
         scale
             The pixel scale of the image plane. The initial triangles have this side length.
@@ -166,31 +176,15 @@ class AbstractSolver:
         -------
         The solver.
         """
-
-        if xp.__name__.startswith("jax"):
-            from autoarray.structures.triangles.coordinate_array import (
-                CoordinateArrayTriangles as triangle_cls,
-            )
-        else:
-            from autoarray.structures.triangles.coordinate_array_np import (
-                CoordinateArrayTrianglesNp as triangle_cls,
-            )
-
-        initial_triangles = triangle_cls.for_limits_and_scale(
+        return cls(
             y_min=y_min,
             y_max=y_max,
             x_min=x_min,
             x_max=x_max,
             scale=scale,
-        )
-
-        return cls(
-            scale=scale,
-            initial_triangles=initial_triangles,
             pixel_scale_precision=pixel_scale_precision,
             magnification_threshold=magnification_threshold,
             neighbor_degree=neighbor_degree,
-            xp=xp,
         )
 
     @property
@@ -204,6 +198,7 @@ class AbstractSolver:
         self,
         tracer: Tracer,
         grid: aa.type.Grid2DLike,
+        xp,
         plane_redshift: Optional[float] = None,
     ) -> aa.type.Grid2DLike:
         """
@@ -213,6 +208,8 @@ class AbstractSolver:
         ----------
         grid
             The image plane grid.
+        xp
+            The array module (``numpy`` or ``jax.numpy``) used for the deflection computation.
 
         Returns
         -------
@@ -224,7 +221,7 @@ class AbstractSolver:
             plane_index = tracer.plane_index_via_redshift_from(redshift=plane_redshift)
 
         deflections = tracer.deflections_between_planes_from(
-            grid=grid, plane_i=0, plane_j=plane_index, xp=self._xp
+            grid=grid, plane_i=0, plane_j=plane_index, xp=xp
         )
         # noinspection PyTypeChecker
         return grid.grid_2d_via_deflection_grid_from(deflection_grid=deflections)
@@ -233,6 +230,7 @@ class AbstractSolver:
         self,
         tracer: Tracer,
         shape: Shape,
+        xp,
         plane_redshift: Optional[float] = None,
     ):
         """
@@ -251,6 +249,8 @@ class AbstractSolver:
             The tracer to use to trace the image plane coordinates to the source plane.
         shape
             The shape in the source plane for which we want to identify the image plane coordinates.
+        xp
+            The array module (``numpy`` or ``jax.numpy``) the solve runs in.
         plane_redshift
             The redshift of the source plane.
 
@@ -267,6 +267,7 @@ class AbstractSolver:
             self.steps(
                 tracer=tracer,
                 shape=shape,
+                xp=xp,
                 plane_redshift=plane_redshift,
             )
         )
@@ -274,7 +275,7 @@ class AbstractSolver:
         return final_step.filtered_triangles
 
     def _filter_low_magnification(
-        self, tracer: Tracer, points: List[Tuple[float, float]]
+        self, tracer: Tracer, points: List[Tuple[float, float]], xp
     ) -> List[Tuple[float, float]]:
         """
         Filter the points to keep only those with an absolute magnification above the threshold.
@@ -283,24 +284,27 @@ class AbstractSolver:
         ----------
         points
             The points to filter.
+        xp
+            The array module used for the magnification calculation.
 
         Returns
         -------
         The points with an absolute magnification above the threshold.
         """
-        points = self._xp.array(points)
+        points = xp.array(points)
         magnifications = ag.LensCalc.from_mass_obj(
             tracer
         ).magnification_2d_via_hessian_from(
-            grid=aa.Grid2DIrregular(points).array, xp=self._xp
+            grid=aa.Grid2DIrregular(points).array, xp=xp
         )
-        mask = self._xp.abs(magnifications) > self.magnification_threshold
-        return self._xp.where(mask[:, None], points, self._xp.nan)
+        mask = xp.abs(magnifications) > self.magnification_threshold
+        return xp.where(mask[:, None], points, xp.nan)
 
     def _plane_triangles(
         self,
         tracer: Tracer,
         triangles: aa.AbstractTriangles,
+        xp,
         plane_redshift,
     ):
         """
@@ -309,6 +313,7 @@ class AbstractSolver:
         plane_grid = self._plane_grid(
             tracer=tracer,
             grid=aa.Grid2DIrregular(triangles.vertices),
+            xp=xp,
             plane_redshift=plane_redshift,
         )
 
@@ -318,6 +323,7 @@ class AbstractSolver:
         self,
         tracer: Tracer,
         shape: Shape,
+        xp,
         plane_redshift: Optional[float] = None,
     ) -> Iterator[Step]:
         """
@@ -327,21 +333,24 @@ class AbstractSolver:
         ----------
         tracer
             The tracer to use to trace the image plane coordinates to the source plane.
-        plane_redshift
-            The redshift of the source plane.
         shape
             The shape in the source plane for which we want to identify the image plane coordinates.
+        xp
+            The array module (``numpy`` or ``jax.numpy``) the step iteration runs in.
+        plane_redshift
+            The redshift of the source plane.
 
         Returns
         -------
         An iterator over the steps of the triangle solver algorithm.
         """
-        initial_triangles = self.initial_triangles
+        initial_triangles = self._initial_triangles(xp)
 
         for number in range(self.n_steps):
             plane_triangles = self._plane_triangles(
                 tracer=tracer,
                 triangles=initial_triangles,
+                xp=xp,
                 plane_redshift=plane_redshift,
             )
 
@@ -367,19 +376,37 @@ class AbstractSolver:
 
     def tree_flatten(self):
         return (), (
+            self.y_min,
+            self.y_max,
+            self.x_min,
+            self.x_max,
             self.scale,
             self.pixel_scale_precision,
             self.magnification_threshold,
-            self.initial_triangles,
+            self.neighbor_degree,
         )
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
+        (
+            y_min,
+            y_max,
+            x_min,
+            x_max,
+            scale,
+            pixel_scale_precision,
+            magnification_threshold,
+            neighbor_degree,
+        ) = aux_data
         return cls(
-            scale=aux_data[0],
-            pixel_scale_precision=aux_data[1],
-            magnification_threshold=aux_data[2],
-            initial_triangles=aux_data[3],
+            y_min=y_min,
+            y_max=y_max,
+            x_min=x_min,
+            x_max=x_max,
+            scale=scale,
+            pixel_scale_precision=pixel_scale_precision,
+            magnification_threshold=magnification_threshold,
+            neighbor_degree=neighbor_degree,
         )
 
 
@@ -388,6 +415,7 @@ class ShapeSolver(AbstractSolver):
         self,
         tracer: Tracer,
         shape: Shape,
+        xp=np,
         plane_redshift: Optional[float] = None,
     ) -> float:
         """
@@ -399,6 +427,8 @@ class ShapeSolver(AbstractSolver):
             A tracer that traces the image plane to the source plane.
         shape
             The shape of an image plane pixel.
+        xp
+            The array module (``numpy`` or ``jax.numpy``) the magnification calculation runs in.
         plane_redshift
             The redshift of the source plane.
 
@@ -409,6 +439,7 @@ class ShapeSolver(AbstractSolver):
         kept_triangles = super().solve_triangles(
             tracer=tracer,
             shape=shape,
+            xp=xp,
             plane_redshift=plane_redshift,
         )
         return kept_triangles.area / shape.area


### PR DESCRIPTION
## Summary

Removes the long-standing double-knob on the point-source JAX path: previously a user had to both pass `xp=jnp` to `PointSolver.for_grid` **and** `use_jax=True` to `AnalysisPoint`. Now the solver is stateless w.r.t. the array module — one solver construction works for both NumPy and JAX, and `AnalysisPoint(use_jax=True)` alone suffices.

Closes #466.

## API Changes

`PointSolver.for_grid` and `PointSolver.for_limits_and_scale` no longer accept `xp=`. The array module is now passed per-call to `solver.solve(xp=...)` / `solver.solve_triangles(xp=...)`. Most user code never calls `.solve()` directly — `AnalysisPoint` threads `xp` through internally based on `use_jax=`.

No backwards-compatibility shim. Workspace scripts that still pass `xp=jnp` to `PointSolver.for_grid` will raise `TypeError`; see the companion workspace PR for the full migration.

See full details below.

## Test Plan

- [ ] `pytest test_autolens/point/` passes (48 tests, NumPy paths only — per the JAX-free unit test policy)
- [ ] `autolens_workspace_test/scripts/jax_likelihood_functions/point_source/{image_plane,point,source_plane}.py` run end-to-end and NumPy log-likelihood matches the JIT-compiled log-likelihood (already verified by upstream session)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed

- `PointSolver.for_grid(..., xp=...)` — `xp` keyword removed
- `PointSolver.for_limits_and_scale(..., xp=...)` — `xp` keyword removed
- `AbstractSolver(initial_triangles=...)` — constructor no longer takes pre-built triangles
- `AbstractSolver.use_jax` attribute
- `AbstractSolver._xp` property

### Added

- `AbstractSolver(y_min, y_max, x_min, x_max, ...)` — constructor now takes geometry primitives
- `AbstractSolver._initial_triangles(xp)` — builds triangles for the requested array module on demand
- `PointSolver.solve(..., xp=np, ...)` — new keyword, defaults to NumPy
- `ShapeSolver.find_magnification(..., xp=np, ...)` — new keyword, defaults to NumPy
- `MockPointSolver.solve(..., xp=np, ...)` — mirrors real solver signature

### Changed Signature

- `AbstractSolver.solve_triangles`, `AbstractSolver.steps`, `AbstractSolver._plane_grid`, `AbstractSolver._plane_triangles`, `AbstractSolver._filter_low_magnification` — now take a required `xp` argument
- `PointSolver` / `AbstractSolver` pytree: `tree_flatten` / `tree_unflatten` now serialize 8 geometry primitives instead of a pre-built `initial_triangles` object

### Migration

- Before:
  ```python
  solver = al.PointSolver.for_grid(grid=grid, pixel_scale_precision=0.001, xp=jnp)
  analysis = al.AnalysisPoint(dataset=dataset, solver=solver, use_jax=True)
  ```
- After:
  ```python
  solver = al.PointSolver.for_grid(grid=grid, pixel_scale_precision=0.001)
  analysis = al.AnalysisPoint(dataset=dataset, solver=solver, use_jax=True)
  ```
- The direct `solver.solve(tracer, source_plane_coordinate)` call is unchanged for NumPy usage. For JAX, pass `xp=jnp` explicitly: `solver.solve(tracer, coord, xp=jnp)`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)