### PR TITLE
fix: drop AdaptImages single-pixelated-galaxy fallback in lens.to_inversion

### DIFF
--- a/autolens/imaging/model/analysis.py
+++ b/autolens/imaging/model/analysis.py
@@ -117,7 +117,9 @@ class AnalysisImaging(AnalysisDataset):
 
         dataset_model = self.dataset_model_via_instance_from(instance=instance)
 
-        adapt_images = self.adapt_images_via_instance_from(instance=instance)
+        adapt_images = self.adapt_images_via_instance_from(
+            instance=instance, galaxies=tracer.galaxies
+        )
 
         return FitImaging(
             dataset=self.dataset,

--- a/autolens/interferometer/model/analysis.py
+++ b/autolens/interferometer/model/analysis.py
@@ -180,7 +180,9 @@ class AnalysisInterferometer(AnalysisDataset):
             instance=instance,
         )
 
-        adapt_images = self.adapt_images_via_instance_from(instance=instance)
+        adapt_images = self.adapt_images_via_instance_from(
+            instance=instance, galaxies=tracer.galaxies
+        )
 
         return FitInterferometer(
             dataset=self.dataset,

--- a/autolens/lens/to_inversion.py
+++ b/autolens/lens/to_inversion.py
@@ -270,24 +270,12 @@ class TracerToInversion(ag.AbstractToInversion):
                 )
 
                 for galaxy in galaxies_with_pixelization_list:
-                    try:
-                        image = self.adapt_images.galaxy_image_dict[galaxy]
-                    except (AttributeError, KeyError, TypeError):
+                    if self.adapt_images is None:
                         image = None
-
-                    # Bug fix whereby for certain models the galaxy doesnt pair correctly.
-
-                    if image is None and len(galaxies_with_pixelization_list) == 1:
-                        galaxy_list = self.adapt_images.galaxy_image_dict.keys()
-                        galaxy_with_pixelization = [
-                            galaxy
-                            for galaxy in galaxy_list
-                            if galaxy.has(cls=aa.Pixelization)
-                        ][0]
-
-                        image = self.adapt_images.galaxy_image_dict[
-                            galaxy_with_pixelization
-                        ]
+                    else:
+                        image = self.adapt_images.image_for_galaxy(
+                            galaxy, self.tracer.galaxies
+                        )
 
                     plane_image_list.append(image)
 
@@ -330,6 +318,7 @@ class TracerToInversion(ag.AbstractToInversion):
                 adapt_images=self.adapt_images,
                 settings=self.settings,
                 xp=self._xp,
+                path_galaxies=self.tracer.galaxies,
             )
 
             image_plane_mesh_grid_list = to_inversion.image_plane_mesh_grid_list


### PR DESCRIPTION
## Summary

Replaces the fragile single-pixelated-galaxy fallback in `autolens/lens/to_inversion.py` with the new `AdaptImages.image_for_galaxy` helper from PyAutoGalaxy. The fallback (lines 280-290) was a workaround for the same `jax.jit`-unflatten Galaxy-identity issue: when a fit had exactly one pixelization, it picked the only entry in `galaxy_image_dict` by `has(cls=Pixelization)`. That covers the common single-source case but is incorrect once a fit has multiple pixelizations.

The new helper looks up adapt images by path-tuple via `tracer.galaxies` ordering, which is stable across the JIT boundary. Per-plane `GalaxiesToInversion` constructions in `image_plane_mesh_grid_pg_list` now pass `path_galaxies=self.tracer.galaxies` so the autogalaxy-side helper sees the full list (the per-plane subset would otherwise misalign with `galaxy_path_list`).

**Depends on https://github.com/PyAutoLabs/PyAutoGalaxy/pull/370**, which introduces `image_for_galaxy` and the `path_galaxies` constructor argument on `GalaxiesToInversion`. Merge order: PyAutoGalaxy first.

## API Changes

`Analysis.fit_from` (imaging + interferometer) passes `galaxies=tracer.galaxies` into `adapt_images_via_instance_from`. No public symbols added or removed in autolens. Internal change. See full details below.

## Test Plan

- [ ] Existing `test_autolens/` suite remains green (256 pass locally).
- [ ] After PyAutoGalaxy PR lands and merges, run the autolens_workspace_test smoke tests for `jax_likelihood_functions/imaging/{rectangular,rectangular_mge,delaunay,delaunay_mge}.py` to confirm the fallback removal doesn't regress single-pixelization fits.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- Single-pixelated-galaxy fallback at `autolens/lens/to_inversion.py:280-290`. The pattern (search dict keys for `has(cls=Pixelization)` and grab `[0]` when `len(galaxies_with_pixelization_list) == 1`) is replaced by the path-tuple lookup in `AdaptImages.image_for_galaxy`.

### Changed Behaviour
- `TracerToInversion.adapt_galaxy_image_pg_list` resolves adapt images via `image_for_galaxy(galaxy, self.tracer.galaxies)` for all pixelization counts, not only the single-pixelization case.
- `TracerToInversion.image_plane_mesh_grid_pg_list` constructs per-plane `GalaxiesToInversion` instances with `path_galaxies=self.tracer.galaxies` so the autogalaxy helper's positional lookup aligns with the full galaxy list rather than the per-plane subset.

### Migration
- Internal — no migration needed. Public `Analysis.fit_from` signatures unchanged.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)