### PR TITLE
fix: synthetic PositionsLH under skip_checks + test_mode

### DIFF
--- a/autolens/analysis/result.py
+++ b/autolens/analysis/result.py
@@ -314,12 +314,33 @@ class Result(AgResultDataset):
         Outside test mode this branch is never taken — bad positions still surface as
         the original error, so production fits are not silently masked.
 
+        Skip-checks safeguard (``PYAUTO_SKIP_CHECKS``): when validation checks are
+        skipped *and* test mode is active, we return a ``PositionsLH`` built from the
+        same synthetic ``[(1.0, 0.0), (-1.0, 0.0)]`` pair (with threshold set to
+        ``minimum_threshold`` or 0.5 if unset). This avoids the expensive
+        multiple-image-position computation while still giving callers a usable
+        ``PositionsLH``, so workspace scripts that chain ``.positions`` continue to
+        work end-to-end. With skip-checks alone (no test mode) the function still
+        returns ``None`` — the production opt-out behaviour is unchanged.
+
         Returns
         -------
         The `PositionsLH` object used to apply a likelihood penalty or resample the positions.
         """
 
         if skip_checks():
+            if is_test_mode():
+                synthetic_positions = aa.Grid2DIrregular(
+                    values=[(1.0, 0.0), (-1.0, 0.0)]
+                )
+                synthetic_threshold = (
+                    minimum_threshold if minimum_threshold is not None else 0.5
+                )
+                return PositionsLH(
+                    positions=synthetic_positions,
+                    threshold=synthetic_threshold,
+                    plane_redshift=plane_redshift,
+                )
             return
 
         positions = (

--- a/test_autolens/analysis/test_result.py
+++ b/test_autolens/analysis/test_result.py
@@ -248,6 +248,38 @@ def test__positions_likelihood_from(analysis_imaging_7x7):
     assert positions_likelihood.threshold == pytest.approx(0.2, 1.0e-4)
 
 
+def test__positions_likelihood_from__skip_checks_returns_none_outside_test_mode(
+    monkeypatch, analysis_imaging_7x7,
+):
+    monkeypatch.setenv("PYAUTO_SKIP_CHECKS", "1")
+    monkeypatch.delenv("PYAUTO_TEST_MODE", raising=False)
+
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=al.Tracer(galaxies=[]))
+    result = res.Result(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
+
+    assert result.positions_likelihood_from(factor=0.1, minimum_threshold=0.2) is None
+
+
+def test__positions_likelihood_from__skip_checks_returns_synthetic_in_test_mode(
+    monkeypatch, analysis_imaging_7x7,
+):
+    monkeypatch.setenv("PYAUTO_SKIP_CHECKS", "1")
+    monkeypatch.setenv("PYAUTO_TEST_MODE", "2")
+
+    samples_summary = al.m.MockSamplesSummary(max_log_likelihood_instance=al.Tracer(galaxies=[]))
+    result = res.Result(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
+
+    positions_likelihood = result.positions_likelihood_from(
+        factor=0.1, minimum_threshold=0.2
+    )
+
+    assert isinstance(positions_likelihood, al.PositionsLH)
+    assert positions_likelihood.threshold == pytest.approx(0.2, 1.0e-4)
+    assert len(positions_likelihood.positions) == 2
+    assert positions_likelihood.positions[0] == pytest.approx((1.0, 0.0))
+    assert positions_likelihood.positions[1] == pytest.approx((-1.0, 0.0))
+
+
 def test__positions_likelihood_from__test_mode_fallback(
     monkeypatch, analysis_imaging_7x7,
 ):


### PR DESCRIPTION
## Summary

Workspace integration scripts using a chained `.positions` extraction (e.g. `scripts/group/features/pixelization/slam.py:735-737`) were failing under the smoke profile (`PYAUTO_TEST_MODE=2 PYAUTO_SKIP_CHECKS=1`) with `AttributeError: 'NoneType' object has no attribute 'positions'`. The cause was `Result.positions_likelihood_from` short-circuiting to `None` when `skip_checks()` is true, instead of falling through to the existing test-mode synthetic-positions safeguard.

This change makes the function return a usable `PositionsLH` (built from the same `[(1.0, 0.0), (-1.0, 0.0)]` synthetic fallback already used elsewhere in the function) when both `skip_checks()` and `is_test_mode()` are active. Production semantics are preserved: with `skip_checks` alone (no test mode) the function still returns `None`.

## API Changes

`autolens.analysis.result.Result.positions_likelihood_from` no longer returns `None` under the combination `PYAUTO_SKIP_CHECKS=1 + PYAUTO_TEST_MODE>0` — it now returns a synthetic `PositionsLH` with `positions=[(1.0, 0.0), (-1.0, 0.0)]` and `threshold=minimum_threshold or 0.5`. Behaviour is unchanged when `skip_checks` alone is active (still returns `None`) and when neither flag is active (full multiple-image-position computation as before).

See full details below.

## Test Plan
- [x] `python -m pytest test_autolens/analysis/test_result.py -k positions_likelihood_from -x` passes (5 tests, including 2 new)
- [x] `autolens_workspace/scripts/group/features/pixelization/slam.py` runs end-to-end under the smoke profile

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `Result.positions_likelihood_from` — under `PYAUTO_SKIP_CHECKS=1 + PYAUTO_TEST_MODE>0`, returns a synthetic `PositionsLH` instead of `None`. Threshold defaults to `minimum_threshold` or 0.5 when unset. Plane redshift is forwarded.

### Added (tests)
- `test__positions_likelihood_from__skip_checks_returns_none_outside_test_mode` — confirms the production-path `None` return is unchanged.
- `test__positions_likelihood_from__skip_checks_returns_synthetic_in_test_mode` — confirms the new synthetic return under skip_checks + test_mode.

### Migration
- No migration needed. Workspace scripts that chain `.positions` on the return value (e.g. `result.positions_likelihood_from(...).positions`) now work end-to-end under the smoke profile without per-script guards.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)