### PR TITLE
Fix mapper-index lookup in source_plane_inversion_centre_from

### DIFF
--- a/autolens/analysis/result.py
+++ b/autolens/analysis/result.py
@@ -441,12 +441,16 @@ class ResultDataset(Result):
                             redshift=plane_redshift
                         )
                     )
+                    # plane_indexes_with_pixelizations is a list of plane indices that
+                    # have a pixelization, in mapper order. The mapper index for a given
+                    # plane is the position of that plane index within the list, not the
+                    # element at [plane_index].
                     mapper_index = (
-                        self.max_log_likelihood_tracer.plane_indexes_with_pixelizations[
+                        self.max_log_likelihood_tracer.plane_indexes_with_pixelizations.index(
                             plane_index
-                        ]
+                        )
                     )
-                except TypeError:
+                except (TypeError, ValueError):
                     mapper_index = 0
 
                 inversion = self.max_log_likelihood_fit.inversion


### PR DESCRIPTION
## Summary
- Fix `IndexError` in `Result.source_plane_inversion_centre_from` when only some planes have pixelizations
- Indexing semantics: `plane_indexes_with_pixelizations` is a list of plane indices in mapper order, so the mapper for a given plane is found via `.index(plane_index)`, not `[plane_index]`
- The previous code only worked when every plane was pixelized (the identity case `[0,1,...].index(i) == [0,1,...][i]`)

## API Changes
None — internal changes only.
See full details below.

## Test Plan
- [x] `pytest test_autolens/analysis/` — 28 passed (3.5s, run by Opus before delegation)
- [x] `autolens_workspace/scripts/imaging/features/advanced/double_einstein_ring/slam.py` runs to completion under `PYAUTO_TEST_MODE=2`
- [ ] Subagent re-runs full `test_autolens/` to confirm no regression

## Why now
Surfaced by triage Cluster F item 4 — `autolens_workspace/scripts/imaging/features/advanced/double_einstein_ring/slam.py` raised a generic `af.exc.FitException` because `analysis.py:84` swallows the underlying exception. Wrapping with a debug shim revealed `IndexError: list index out of range` at `result.py:445`.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
None.

### Added
None.

### Changed Behaviour
- `Result.source_plane_inversion_centre_from(plane_redshift=...)` no longer raises `IndexError` when only some planes have a pixelization. Previously raised when `plane_indexes_with_pixelizations` had fewer entries than the plane index of the source. Now correctly looks up the mapper index via `.index()`.

### Migration
None required.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)