### PR TITLE
refactor: replace os.path with pathlib

### DIFF
--- a/autolens/analysis/positions.py
+++ b/autolens/analysis/positions.py
@@ -18,7 +18,7 @@ constraints (e.g. quad-lens quasars).
 """
 import numpy as np
 from typing import Optional
-from os import path
+from pathlib import Path
 
 import autoarray as aa
 import autofit as af
@@ -124,7 +124,7 @@ class PositionsLH:
 
         flag = "w+" if overwrite_file else "a+"
 
-        with open_(path.join(output_path, "positions.info"), flag) as f:
+        with open_(Path(output_path) / "positions.info", flag) as f:
 
             positions_fit = SourceMaxSeparation(
                 data=self.positions,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,13 +10,13 @@ import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
+# documentation root, use Path(...).resolve() to make it absolute, like shown here.
 #
 
-import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.abspath("."))
+sys.path.insert(0, str(Path(".").resolve()))
 
 import autolens
 

--- a/test_autolens/analysis/analysis/test_analysis_dataset.py
+++ b/test_autolens/analysis/analysis/test_analysis_dataset.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 import os
 import pytest
 
@@ -9,7 +9,7 @@ import autofit as af
 import autolens as al
 from autolens import exc
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__modify_before_fit__inversion_no_positions_likelihood__raises_exception(

--- a/test_autolens/analysis/analysis/test_analysis_lens.py
+++ b/test_autolens/analysis/analysis/test_analysis_lens.py
@@ -1,10 +1,10 @@
-from os import path
+from pathlib import Path
 import pytest
 
 import autofit as af
 import autolens as al
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__tracer_for_instance(analysis_imaging_7x7):

--- a/test_autolens/analysis/test_analysis.py
+++ b/test_autolens/analysis/test_analysis.py
@@ -1,5 +1,5 @@
 import numpy as np
-from os import path
+from pathlib import Path
 import os
 import pytest
 
@@ -10,7 +10,7 @@ import autofit as af
 import autolens as al
 from autolens import exc
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__tracer_for_instance(analysis_imaging_7x7):

--- a/test_autolens/analysis/test_plotter.py
+++ b/test_autolens/analysis/test_plotter.py
@@ -1,21 +1,20 @@
-import os
 import shutil
-from os import path
+from pathlib import Path
 
 import pytest
 import autolens as al
 from autolens.analysis import plotter as vis
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plotter_plotter_setup():
-    return path.join("{}".format(directory), "files")
+    return directory / "files"
 
 
 def test__tracer(masked_imaging_7x7, tracer_x2_plane_7x7, plot_path, plot_patch):
-    if os.path.exists(plot_path):
+    if plot_path.exists():
         shutil.rmtree(plot_path)
 
     plotter = vis.Plotter(image_path=plot_path)
@@ -25,21 +24,21 @@ def test__tracer(masked_imaging_7x7, tracer_x2_plane_7x7, plot_path, plot_patch)
         grid=masked_imaging_7x7.grids.lp,
     )
 
-    assert path.join(plot_path, "galaxies_images.png") in plot_patch.paths
+    assert str(plot_path / "galaxies_images.png") in plot_patch.paths
 
     image = al.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "tracer.fits"), hdu=0
+        file_path=plot_path / "tracer.fits", hdu=0
     )
 
     assert image.shape == (5, 5)
 
 
 def test__image_with_positions(image_7x7, positions_x2, plot_path, plot_patch):
-    if os.path.exists(plot_path):
+    if plot_path.exists():
         shutil.rmtree(plot_path)
 
     plotter = vis.Plotter(image_path=plot_path)
 
     plotter.image_with_positions(image=image_7x7, positions=positions_x2)
 
-    assert path.join(plot_path, "image_with_positions.png") in plot_patch.paths
+    assert str(plot_path / "image_with_positions.png") in plot_patch.paths

--- a/test_autolens/analysis/test_positions.py
+++ b/test_autolens/analysis/test_positions.py
@@ -1,5 +1,5 @@
 import os
-from os import path
+from pathlib import Path
 import pytest
 
 from autoconf.dictable import output_to_json, from_json, from_dict
@@ -21,9 +21,7 @@ def test__check_positions_on_instantiation():
 
 
 def test__output_positions_info():
-    output_path = path.join(
-        "{}".format(os.path.dirname(os.path.realpath(__file__))), "files"
-    )
+    output_path = Path(__file__).resolve().parent / "files"
 
     positions_likelihood = al.PositionsLH(
         positions=al.Grid2DIrregular([(1.0, 2.0), (3.0, 4.0)]), threshold=0.1
@@ -35,7 +33,7 @@ def test__output_positions_info():
 
     positions_likelihood.output_positions_info(output_path=output_path, tracer=tracer)
 
-    positions_file = path.join(output_path, "positions.info")
+    positions_file = output_path / "positions.info"
 
     with open_(positions_file, "r") as f:
         output = f.readlines()

--- a/test_autolens/analysis/test_result.py
+++ b/test_autolens/analysis/test_result.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import numpy as np
 import pytest
 
@@ -9,7 +9,7 @@ from autoarray import Array2D
 from autolens.analysis import result as res
 from autolens.imaging.model.result import ResultImaging
 
-directory = os.path.dirname(os.path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__max_log_likelihood_tracer(

--- a/test_autolens/conftest.py
+++ b/test_autolens/conftest.py
@@ -1,5 +1,5 @@
 import os
-from os import path
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -21,7 +21,7 @@ class PlotPatch:
         self.paths = []
 
     def __call__(self, path, *args, **kwargs):
-        self.paths.append(path)
+        self.paths.append(str(path))
 
 
 @pytest.fixture(name="plot_patch")
@@ -34,14 +34,14 @@ def make_plot_patch(monkeypatch):
     return plot_patch
 
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(autouse=True)
 def set_config_path(request):
     conf.instance.push(
-        new_path=path.join(directory, "config"),
-        output_path=path.join(directory, "output"),
+        new_path=directory / "config",
+        output_path=directory / "output",
     )
 
 
@@ -51,7 +51,7 @@ def remove_logs():
     for d, _, files in os.walk(directory):
         for file in files:
             if file.endswith(".log"):
-                os.remove(path.join(d, file))
+                os.remove(Path(d) / file)
 
 
 ############

--- a/test_autolens/imaging/model/test_analysis_imaging.py
+++ b/test_autolens/imaging/model/test_analysis_imaging.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 import pytest
 
 import autofit as af
@@ -10,7 +10,7 @@ from autolens.imaging.model.result import ResultImaging
 from autolens import exc
 
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__make_result__result_imaging_is_returned(masked_imaging_7x7):

--- a/test_autolens/imaging/model/test_plotter_imaging.py
+++ b/test_autolens/imaging/model/test_plotter_imaging.py
@@ -1,23 +1,22 @@
-import os
 import shutil
-from os import path
+from pathlib import Path
 
 import pytest
 import autolens as al
 from autolens.imaging.model.plotter import PlotterImaging
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plotter_plotter_setup():
-    return path.join("{}".format(directory), "files")
+    return directory / "files"
 
 
 def test__fit_imaging(
     fit_imaging_x2_plane_inversion_7x7, plot_path, plot_patch
 ):
-    if os.path.exists(plot_path):
+    if plot_path.exists():
         shutil.rmtree(plot_path)
 
     plotter = PlotterImaging(image_path=plot_path)
@@ -26,18 +25,18 @@ def test__fit_imaging(
         fit=fit_imaging_x2_plane_inversion_7x7,
     )
 
-    assert path.join(plot_path, "tracer.png") in plot_patch.paths
-    assert path.join(plot_path, "fit.png") in plot_patch.paths
-    assert path.join(plot_path, "fit_log10.png") in plot_patch.paths
+    assert str(plot_path / "tracer.png") in plot_patch.paths
+    assert str(plot_path / "fit.png") in plot_patch.paths
+    assert str(plot_path / "fit_log10.png") in plot_patch.paths
 
     image = al.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "fit.fits"), hdu=0
+        file_path=plot_path / "fit.fits", hdu=0
     )
 
     assert image.shape == (5, 5)
 
     image = al.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "model_galaxy_images.fits"), hdu=0
+        file_path=plot_path / "model_galaxy_images.fits", hdu=0
     )
 
     assert image.shape == (5, 5)
@@ -45,11 +44,11 @@ def test__fit_imaging(
 def test__fit_imaging_combined(
     fit_imaging_x2_plane_inversion_7x7, plot_path, plot_patch
 ):
-    if path.exists(plot_path):
+    if plot_path.exists():
         shutil.rmtree(plot_path)
 
     visualizer = PlotterImaging(image_path=plot_path)
 
     visualizer.fit_imaging_combined(fit_list=2 * [fit_imaging_x2_plane_inversion_7x7])
 
-    assert path.join(plot_path, "fit_combined.png") in plot_patch.paths
+    assert str(plot_path / "fit_combined.png") in plot_patch.paths

--- a/test_autolens/imaging/plot/test_fit_imaging_plots.py
+++ b/test_autolens/imaging/plot/test_fit_imaging_plots.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 
 import pytest
 
@@ -13,14 +13,12 @@ from autolens.imaging.plot.fit_imaging_plots import (
     subplot_fit_combined_log10,
 )
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_fit_imaging_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "plots", "fit"
-    )
+    return directory / "files" / "plots" / "fit"
 
 
 def test__subplot_fit__two_plane_tracer__output_file_created(
@@ -31,7 +29,7 @@ def test__subplot_fit__two_plane_tracer__output_file_created(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit.png") in plot_patch.paths
+    assert str(plot_path / "fit.png") in plot_patch.paths
 
 
 def test__subplot_fit__single_plane_tracer__delegates_to_x1_plane_and_creates_file(
@@ -42,7 +40,7 @@ def test__subplot_fit__single_plane_tracer__delegates_to_x1_plane_and_creates_fi
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit_x1_plane.png") in plot_patch.paths
+    assert str(plot_path / "fit_x1_plane.png") in plot_patch.paths
 
 
 def test__subplot_fit_x1_plane__single_plane_tracer__output_file_created(
@@ -53,7 +51,7 @@ def test__subplot_fit_x1_plane__single_plane_tracer__output_file_created(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit_x1_plane.png") in plot_patch.paths
+    assert str(plot_path / "fit_x1_plane.png") in plot_patch.paths
 
 
 def test__subplot_fit_log10__two_plane_tracer__output_file_created(
@@ -64,7 +62,7 @@ def test__subplot_fit_log10__two_plane_tracer__output_file_created(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit_log10.png") in plot_patch.paths
+    assert str(plot_path / "fit_log10.png") in plot_patch.paths
 
 
 def test__subplot_fit_log10__single_plane_tracer__delegates_to_x1_plane_and_creates_file(
@@ -75,7 +73,7 @@ def test__subplot_fit_log10__single_plane_tracer__delegates_to_x1_plane_and_crea
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit_log10.png") in plot_patch.paths
+    assert str(plot_path / "fit_log10.png") in plot_patch.paths
 
 
 def test__subplot_fit_log10_x1_plane__single_plane_tracer__output_file_created(
@@ -86,7 +84,7 @@ def test__subplot_fit_log10_x1_plane__single_plane_tracer__output_file_created(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit_log10.png") in plot_patch.paths
+    assert str(plot_path / "fit_log10.png") in plot_patch.paths
 
 
 def test__subplot_of_planes__no_plane_index_specified__all_plane_files_created(
@@ -98,8 +96,8 @@ def test__subplot_of_planes__no_plane_index_specified__all_plane_files_created(
         output_format="png",
     )
 
-    assert path.join(plot_path, "fit_of_plane_0.png") in plot_patch.paths
-    assert path.join(plot_path, "fit_of_plane_1.png") in plot_patch.paths
+    assert str(plot_path / "fit_of_plane_0.png") in plot_patch.paths
+    assert str(plot_path / "fit_of_plane_1.png") in plot_patch.paths
 
 
 def test__subplot_of_planes__plane_index_0_specified__only_plane_0_file_created(
@@ -112,8 +110,8 @@ def test__subplot_of_planes__plane_index_0_specified__only_plane_0_file_created(
         plane_index=0,
     )
 
-    assert path.join(plot_path, "fit_of_plane_0.png") in plot_patch.paths
-    assert path.join(plot_path, "fit_of_plane_1.png") not in plot_patch.paths
+    assert str(plot_path / "fit_of_plane_0.png") in plot_patch.paths
+    assert str(plot_path / "fit_of_plane_1.png") not in plot_patch.paths
 
 
 def test__subplot_tracer_from_fit__two_plane_tracer__output_file_created(
@@ -124,7 +122,7 @@ def test__subplot_tracer_from_fit__two_plane_tracer__output_file_created(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "tracer.png") in plot_patch.paths
+    assert str(plot_path / "tracer.png") in plot_patch.paths
 
 
 def test__subplot_fit_combined__list_of_two_fits__output_file_created(
@@ -135,7 +133,7 @@ def test__subplot_fit_combined__list_of_two_fits__output_file_created(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit_combined.png") in plot_patch.paths
+    assert str(plot_path / "fit_combined.png") in plot_patch.paths
 
 
 def test__subplot_fit_combined_log10__list_of_two_fits__output_file_created(
@@ -146,4 +144,4 @@ def test__subplot_fit_combined_log10__list_of_two_fits__output_file_created(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit_combined_log10.png") in plot_patch.paths
+    assert str(plot_path / "fit_combined_log10.png") in plot_patch.paths

--- a/test_autolens/imaging/test_simulate_and_fit_imaging.py
+++ b/test_autolens/imaging/test_simulate_and_fit_imaging.py
@@ -1,5 +1,5 @@
 import os
-from os import path
+from pathlib import Path
 import shutil
 
 import autolens as al
@@ -32,34 +32,30 @@ def test__perfect_fit__chi_squared_0():
         shape_native=dataset.data.shape_native, pixel_scales=0.2
     )
 
-    file_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "data_temp",
-        "simulate_and_fit",
-    )
+    file_path = Path(__file__).resolve().parent / "data_temp" / "simulate_and_fit"
 
     try:
         shutil.rmtree(file_path)
     except FileNotFoundError:
         pass
 
-    if path.exists(file_path) is False:
+    if not file_path.exists():
         os.makedirs(file_path)
 
     from autoarray.dataset.plot.imaging_plots import fits_imaging
 
     fits_imaging(
         dataset=dataset,
-        data_path=path.join(file_path, "data.fits"),
-        noise_map_path=path.join(file_path, "noise_map.fits"),
-        psf_path=path.join(file_path, "psf.fits"),
+        data_path=file_path / "data.fits",
+        noise_map_path=file_path / "noise_map.fits",
+        psf_path=file_path / "psf.fits",
         overwrite=True,
     )
 
     dataset = al.Imaging.from_fits(
-        data_path=path.join(file_path, "data.fits"),
-        noise_map_path=path.join(file_path, "noise_map.fits"),
-        psf_path=path.join(file_path, "psf.fits"),
+        data_path=file_path / "data.fits",
+        noise_map_path=file_path / "noise_map.fits",
+        psf_path=file_path / "psf.fits",
         pixel_scales=0.2,
         over_sample_size_lp=1
     )
@@ -76,11 +72,9 @@ def test__perfect_fit__chi_squared_0():
 
     assert fit.chi_squared == pytest.approx(0.0, 1e-4)
 
-    file_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "data_temp"
-    )
+    file_path = Path(__file__).resolve().parent / "data_temp"
 
-    if path.exists(file_path) is True:
+    if file_path.exists():
         shutil.rmtree(file_path)
 
 
@@ -644,34 +638,30 @@ def test__fit_figure_of_merit__mge_mass_model(masked_imaging_7x7, masked_imaging
         shape_native=dataset.data.shape_native, pixel_scales=0.2
     )
 
-    file_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "data_temp",
-        "simulate_and_fit",
-    )
+    file_path = Path(__file__).resolve().parent / "data_temp" / "simulate_and_fit"
 
     try:
         shutil.rmtree(file_path)
     except FileNotFoundError:
         pass
 
-    if path.exists(file_path) is False:
+    if not file_path.exists():
         os.makedirs(file_path)
 
     from autoarray.dataset.plot.imaging_plots import fits_imaging
 
     fits_imaging(
         dataset=dataset,
-        data_path=path.join(file_path, "data.fits"),
-        noise_map_path=path.join(file_path, "noise_map.fits"),
-        psf_path=path.join(file_path, "psf.fits"),
+        data_path=file_path / "data.fits",
+        noise_map_path=file_path / "noise_map.fits",
+        psf_path=file_path / "psf.fits",
         overwrite=True,
     )
 
     dataset = al.Imaging.from_fits(
-        data_path=path.join(file_path, "data.fits"),
-        noise_map_path=path.join(file_path, "noise_map.fits"),
-        psf_path=path.join(file_path, "psf.fits"),
+        data_path=file_path / "data.fits",
+        noise_map_path=file_path / "noise_map.fits",
+        psf_path=file_path / "psf.fits",
         pixel_scales=0.2,
         over_sample_size_lp=8
     )
@@ -726,9 +716,7 @@ def test__fit_figure_of_merit__mge_mass_model(masked_imaging_7x7, masked_imaging
 
     assert fit.chi_squared == pytest.approx(3.295535243634485e-05, 1e-4)
 
-    file_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "data_temp"
-    )
+    file_path = Path(__file__).resolve().parent / "data_temp"
 
-    if path.exists(file_path) is True:
+    if file_path.exists():
         shutil.rmtree(file_path)

--- a/test_autolens/interferometer/model/test_analysis_interferometer.py
+++ b/test_autolens/interferometer/model/test_analysis_interferometer.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 import pytest
 
 import autofit as af
@@ -7,7 +7,7 @@ from autolens import exc
 
 from autolens.interferometer.model.result import ResultInterferometer
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__make_result__result_interferometer_is_returned(interferometer_7):

--- a/test_autolens/interferometer/model/test_plotter_interferometer.py
+++ b/test_autolens/interferometer/model/test_plotter_interferometer.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 
 import pytest
 
@@ -8,12 +8,12 @@ from autolens.interferometer.model.plotter import (
     PlotterInterferometer,
 )
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plotter_plotter_setup():
-    return path.join("{}".format(directory), "files")
+    return directory / "files"
 
 
 def test__fit_interferometer(
@@ -27,18 +27,18 @@ def test__fit_interferometer(
         fit=fit_interferometer_x2_plane_7x7,
     )
 
-    assert path.join(plot_path, "fit.png") in plot_patch.paths
-    assert path.join(plot_path, "fit_real_space.png") in plot_patch.paths
-    assert path.join(plot_path, "fit_dirty_images.png") in plot_patch.paths
+    assert str(plot_path / "fit.png") in plot_patch.paths
+    assert str(plot_path / "fit_real_space.png") in plot_patch.paths
+    assert str(plot_path / "fit_dirty_images.png") in plot_patch.paths
 
     image = al.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "galaxy_images.fits"), hdu=0
+        file_path=plot_path / "galaxy_images.fits", hdu=0
     )
 
     assert image.shape == (5, 5)
 
     image = al.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "dirty_images.fits"), hdu=0
+        file_path=plot_path / "dirty_images.fits", hdu=0
     )
 
     assert image.shape == (5, 5)

--- a/test_autolens/interferometer/model/test_result_interferometer.py
+++ b/test_autolens/interferometer/model/test_result_interferometer.py
@@ -1,7 +1,7 @@
-import os
+from pathlib import Path
 
 
-directory = os.path.dirname(os.path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 class TestResultInterferometer:

--- a/test_autolens/interferometer/plot/test_fit_interferometer_plots.py
+++ b/test_autolens/interferometer/plot/test_fit_interferometer_plots.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 import pytest
 
 from autolens.interferometer.plot.fit_interferometer_plots import (
@@ -9,9 +9,7 @@ from autolens.interferometer.plot.fit_interferometer_plots import (
 
 @pytest.fixture(name="plot_path")
 def make_fit_interferometer_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "plots", "fit"
-    )
+    return Path(__file__).resolve().parent / "files" / "plots" / "fit"
 
 
 def test__subplot_fit(
@@ -22,7 +20,7 @@ def test__subplot_fit(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit.png") in plot_patch.paths
+    assert str(plot_path / "fit.png") in plot_patch.paths
 
 
 def test__subplot_fit_real_space(
@@ -36,4 +34,4 @@ def test__subplot_fit_real_space(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit_real_space.png") in plot_patch.paths
+    assert str(plot_path / "fit_real_space.png") in plot_patch.paths

--- a/test_autolens/interferometer/test_simulate_and_fit_interferometer.py
+++ b/test_autolens/interferometer/test_simulate_and_fit_interferometer.py
@@ -1,5 +1,5 @@
 import os
-from os import path
+from pathlib import Path
 import shutil
 
 import autolens as al
@@ -34,27 +34,23 @@ def test__perfect_fit__chi_squared_0():
 
     dataset = simulator.via_tracer_from(tracer=tracer, grid=grid)
 
-    file_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "data_temp",
-        "simulate_and_fit",
-    )
+    file_path = Path(__file__).resolve().parent / "data_temp" / "simulate_and_fit"
 
     try:
         shutil.rmtree(file_path)
     except FileNotFoundError:
         pass
 
-    if path.exists(file_path) is False:
+    if not file_path.exists():
         os.makedirs(file_path)
 
     from autoarray.dataset.plot.interferometer_plots import fits_interferometer
 
     fits_interferometer(
         dataset=dataset,
-        data_path=path.join(file_path, "data.fits"),
-        noise_map_path=path.join(file_path, "noise_map.fits"),
-        uv_wavelengths_path=path.join(file_path, "uv_wavelengths.fits"),
+        data_path=file_path / "data.fits",
+        noise_map_path=file_path / "noise_map.fits",
+        uv_wavelengths_path=file_path / "uv_wavelengths.fits",
         overwrite=True,
     )
 
@@ -64,9 +60,9 @@ def test__perfect_fit__chi_squared_0():
     )
 
     dataset = al.Interferometer.from_fits(
-        data_path=path.join(file_path, "data.fits"),
-        noise_map_path=path.join(file_path, "noise_map.fits"),
-        uv_wavelengths_path=path.join(file_path, "uv_wavelengths.fits"),
+        data_path=file_path / "data.fits",
+        noise_map_path=file_path / "noise_map.fits",
+        uv_wavelengths_path=file_path / "uv_wavelengths.fits",
         real_space_mask=real_space_mask,
         transformer_class=al.TransformerDFT,
     )
@@ -101,11 +97,9 @@ def test__perfect_fit__chi_squared_0():
     )
     assert abs(fit.chi_squared) < 1.0e-4
 
-    file_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "data_temp"
-    )
+    file_path = Path(__file__).resolve().parent / "data_temp"
 
-    if path.exists(file_path) is True:
+    if file_path.exists():
         shutil.rmtree(file_path)
 
 

--- a/test_autolens/lens/plot/test_tracer_plots.py
+++ b/test_autolens/lens/plot/test_tracer_plots.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 
 import pytest
 
@@ -11,17 +11,12 @@ from autolens.lens.plot.tracer_plots import (
     fits_source_plane_images,
 )
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_tracer_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "plots",
-        "tracer",
-    )
+    return directory / "files" / "plots" / "tracer"
 
 
 def test__subplot_tracer__two_plane_tracer__output_file_created(
@@ -33,7 +28,7 @@ def test__subplot_tracer__two_plane_tracer__output_file_created(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "tracer.png") in plot_patch.paths
+    assert str(plot_path / "tracer.png") in plot_patch.paths
 
 
 def test__subplot_galaxies_images__two_plane_tracer__output_file_created(
@@ -45,7 +40,7 @@ def test__subplot_galaxies_images__two_plane_tracer__output_file_created(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "galaxies_images.png") in plot_patch.paths
+    assert str(plot_path / "galaxies_images.png") in plot_patch.paths
 
 
 def test__subplot_lensed_images__two_plane_tracer__output_file_created(
@@ -57,7 +52,7 @@ def test__subplot_lensed_images__two_plane_tracer__output_file_created(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "lensed_images.png") in plot_patch.paths
+    assert str(plot_path / "lensed_images.png") in plot_patch.paths
 
 
 def test__fits_tracer__two_plane_tracer__tracer_fits_file_written(

--- a/test_autolens/lens/test_operate.py
+++ b/test_autolens/lens/test_operate.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pytest
-from os import path
+from pathlib import Path
 
 import autogalaxy as ag
 import autolens as al
 
-test_path = path.join("{}".format(path.dirname(path.realpath(__file__))), "files")
+test_path = Path(__file__).resolve().parent / "files"
 
 
 def test__operate_image__blurred_images_2d_via_psf_from__for_tracer_gives_list_of_planes(

--- a/test_autolens/lens/test_to_inversion.py
+++ b/test_autolens/lens/test_to_inversion.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pytest
-from os import path
+from pathlib import Path
 
 import autolens as al
 
-test_path = path.join("{}".format(path.dirname(path.realpath(__file__))), "files")
+test_path = Path(__file__).resolve().parent / "files"
 
 
 def test__lp_linear_func_galaxy_dict_from(masked_imaging_7x7):

--- a/test_autolens/lens/test_tracer.py
+++ b/test_autolens/lens/test_tracer.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from os import path
+from pathlib import Path
 
 from autoconf.dictable import from_json, output_to_json
 import autofit as af
@@ -1046,9 +1046,7 @@ def test__instance_into_tracer__retains_dictionary_access():
 
 
 def test__output_to_and_load_from_json():
-    json_file = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "tracer.json"
-    )
+    json_file = Path(__file__).resolve().parent / "files" / "tracer.json"
 
     g0 = al.Galaxy(redshift=0.5, mass_profile=al.mp.IsothermalSph(einstein_radius=1.0))
     g1 = al.Galaxy(redshift=1.0)

--- a/test_autolens/point/model/test_analysis_point.py
+++ b/test_autolens/point/model/test_analysis_point.py
@@ -1,11 +1,11 @@
-from os import path
+from pathlib import Path
 
 import autofit as af
 import autolens as al
 
 from autolens.point.model.result import ResultPoint
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def _test__make_result__result_imaging_is_returned(point_dataset):

--- a/test_autolens/point/model/test_plotter_point.py
+++ b/test_autolens/point/model/test_plotter_point.py
@@ -1,24 +1,23 @@
-import os
 import shutil
-from os import path
+from pathlib import Path
 
 import pytest
 from autolens.point.model.plotter import PlotterPoint
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plotter_plotter_setup():
-    return path.join("{}".format(directory), "files")
+    return directory / "files"
 
 
 def test__fit_point(fit_point_dataset_x2_plane, plot_path, plot_patch):
-    if os.path.exists(plot_path):
+    if plot_path.exists():
         shutil.rmtree(plot_path)
 
     plotter = PlotterPoint(image_path=plot_path)
 
     plotter.fit_point(fit=fit_point_dataset_x2_plane)
 
-    assert path.join(plot_path, "fit.png") in plot_patch.paths
+    assert str(plot_path / "fit.png") in plot_patch.paths

--- a/test_autolens/point/plot/test_fit_point_plots.py
+++ b/test_autolens/point/plot/test_fit_point_plots.py
@@ -1,20 +1,15 @@
-from os import path
+from pathlib import Path
 
 import pytest
 
 from autolens.point.plot.fit_point_plots import subplot_fit
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_fit_point_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "plots",
-        "fit_point",
-    )
+    return Path(__file__).resolve().parent / "files" / "plots" / "fit_point"
 
 
 def test__subplot_fit(fit_point_dataset_x2_plane, plot_path, plot_patch):
@@ -23,4 +18,4 @@ def test__subplot_fit(fit_point_dataset_x2_plane, plot_path, plot_patch):
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit.png") in plot_patch.paths
+    assert str(plot_path / "fit.png") in plot_patch.paths

--- a/test_autolens/point/plot/test_point_dataset_plots.py
+++ b/test_autolens/point/plot/test_point_dataset_plots.py
@@ -1,20 +1,15 @@
-from os import path
+from pathlib import Path
 
 import pytest
 
 from autolens.point.plot.point_dataset_plots import subplot_dataset
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_point_dataset_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "plots",
-        "point_dataset",
-    )
+    return directory / "files" / "plots" / "point_dataset"
 
 
 def test__subplot_dataset(point_dataset, plot_path, plot_patch):
@@ -23,4 +18,4 @@ def test__subplot_dataset(point_dataset, plot_path, plot_patch):
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "dataset_point.png") in plot_patch.paths
+    assert str(plot_path / "dataset_point.png") in plot_patch.paths

--- a/test_autolens/point/test_dataset.py
+++ b/test_autolens/point/test_dataset.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 import autolens as al
@@ -42,7 +40,7 @@ def test__csv_round_trip__positions_only(tmp_path):
         positions_noise_map=[0.05, 0.05, 0.1],
     )
 
-    file_path = os.path.join(tmp_path, "point_dataset.csv")
+    file_path = tmp_path / "point_dataset.csv"
     dataset.to_csv(file_path)
 
     loaded = al.PointDataset.from_csv(file_path)
@@ -63,7 +61,7 @@ def test__csv_round_trip__positions_and_fluxes(tmp_path):
         fluxes_noise_map=[0.1, 0.15],
     )
 
-    file_path = os.path.join(tmp_path, "point_dataset.csv")
+    file_path = tmp_path / "point_dataset.csv"
     dataset.to_csv(file_path)
 
     loaded = al.PointDataset.from_csv(file_path)
@@ -82,7 +80,7 @@ def test__csv_round_trip__positions_and_time_delays(tmp_path):
         time_delays_noise_map=[1.0, 2.5],
     )
 
-    file_path = os.path.join(tmp_path, "point_dataset.csv")
+    file_path = tmp_path / "point_dataset.csv"
     dataset.to_csv(file_path)
 
     loaded = al.PointDataset.from_csv(file_path)
@@ -103,7 +101,7 @@ def test__csv_round_trip__positions_fluxes_and_time_delays(tmp_path):
         time_delays_noise_map=[1.0, 2.5, 3.0],
     )
 
-    file_path = os.path.join(tmp_path, "point_dataset.csv")
+    file_path = tmp_path / "point_dataset.csv"
     dataset.to_csv(file_path)
 
     loaded = al.PointDataset.from_csv(file_path)
@@ -125,7 +123,7 @@ def test__csv_list_round_trip__heterogeneous_optional_columns(tmp_path):
         positions_noise_map=[0.1, 0.1],
     )
 
-    file_path = os.path.join(tmp_path, "point_datasets.csv")
+    file_path = tmp_path / "point_datasets.csv"
     al.output_to_csv([with_fluxes, positions_only], file_path)
 
     loaded = al.list_from_csv(file_path)
@@ -145,7 +143,7 @@ def test__csv_round_trip__redshift(tmp_path):
         redshift=2.5,
     )
 
-    file_path = os.path.join(tmp_path, "point_dataset.csv")
+    file_path = tmp_path / "point_dataset.csv"
     dataset.to_csv(file_path)
 
     loaded = al.PointDataset.from_csv(file_path)
@@ -167,7 +165,7 @@ def test__csv_list_round_trip__mixed_redshift_presence(tmp_path):
         positions_noise_map=[0.1, 0.1],
     )
 
-    file_path = os.path.join(tmp_path, "point_datasets.csv")
+    file_path = tmp_path / "point_datasets.csv"
     al.output_to_csv([with_redshift, without_redshift], file_path)
 
     loaded = al.list_from_csv(file_path)
@@ -180,7 +178,7 @@ def test__csv_list_round_trip__mixed_redshift_presence(tmp_path):
 
 
 def test__list_from_csv__inconsistent_redshift_raises(tmp_path):
-    file_path = os.path.join(tmp_path, "point_datasets.csv")
+    file_path = tmp_path / "point_datasets.csv"
     with open(file_path, "w") as f:
         f.write("name,y,x,positions_noise,redshift\n")
         f.write("source_0,0.0,0.0,0.05,1.5\n")
@@ -191,7 +189,7 @@ def test__list_from_csv__inconsistent_redshift_raises(tmp_path):
 
 
 def test__list_from_csv__partial_redshift_raises(tmp_path):
-    file_path = os.path.join(tmp_path, "point_datasets.csv")
+    file_path = tmp_path / "point_datasets.csv"
     with open(file_path, "w") as f:
         f.write("name,y,x,positions_noise,redshift\n")
         f.write("source_0,0.0,0.0,0.05,1.5\n")
@@ -215,7 +213,7 @@ def test__from_csv__multiple_groups_requires_name(tmp_path):
         ),
     ]
 
-    file_path = os.path.join(tmp_path, "point_datasets.csv")
+    file_path = tmp_path / "point_datasets.csv"
     al.output_to_csv(datasets, file_path)
 
     with pytest.raises(ValueError):

--- a/test_autolens/quantity/model/test_analysis_quantity.py
+++ b/test_autolens/quantity/model/test_analysis_quantity.py
@@ -1,11 +1,11 @@
-from os import path
+from pathlib import Path
 
 import autofit as af
 import autolens as al
 
 from autolens.quantity.model.result import ResultQuantity
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__make_result__result_quantity_is_returned(dataset_quantity_7x7_array_2d):

--- a/test_autolens/test_config.py
+++ b/test_autolens/test_config.py
@@ -1,10 +1,10 @@
-from os import path
+from pathlib import Path
 
 import pytest
 
 from autoconf import conf
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 class MockClass:
@@ -16,7 +16,7 @@ def make_label_config():
     print(directory, "config")
 
     config = conf.Config(
-        path.join(directory, "config"), output_path=path.join(directory, "output")
+        directory / "config", output_path=directory / "output"
     )
 
     return config["notation"]["label"]


### PR DESCRIPTION
## Summary

Mechanical refactor replacing all `os.path.*` and bare `path.*` (from `from os import path`) usages with `pathlib.Path`. Part of cross-repo issue PyAutoLabs/PyAutoFit#1257 — the codebase already used `pathlib` extensively in newer code; this sweeps up the remaining legacy usages for consistency.

## API Changes

None — internal changes only. All public function signatures unchanged. Implementation switches from string-style joins to Path objects, but returned values, accepted argument types, and external behaviour are unchanged. Some test fixtures (`PlotPatch`) now stringify recorded paths to keep assertions stable.

See full details below.

## Test Plan

- [ ] `python -m pytest test_<repo>/` passes (CI)
- [ ] Verified locally as part of cross-repo sweep (3,188 tests across PyAutoConf/PyAutoFit/PyAutoArray/PyAutoGalaxy/PyAutoLens)
- [ ] No public API changed — workspace scripts should be unaffected (separate workspace PR follows for tutorial/example consistency)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None — no public symbols removed

### Added
- None — no new public symbols

### Renamed
- None

### Changed Signature
- None

### Changed Behaviour
- None observable. Internal helpers now build paths with `Path / "..."` instead of `os.path.join`, but consumers that accept `str | os.PathLike` see the same effective path.

### Migration
- No user migration needed.

</details>

Refs PyAutoLabs/PyAutoFit#1257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)