### PR TITLE
fix: AnalysisInterferometer.__init__ kwargs passthrough

### DIFF
--- a/autolens/interferometer/model/analysis.py
+++ b/autolens/interferometer/model/analysis.py
@@ -47,6 +47,7 @@ class AnalysisInterferometer(AnalysisDataset):
         raise_inversion_positions_likelihood_exception: bool = True,
         title_prefix: str = None,
         use_jax: bool = True,
+        **kwargs,
     ):
         """
         Analysis classes are used by PyAutoFit to fit a model to a dataset via a non-linear search.
@@ -98,6 +99,7 @@ class AnalysisInterferometer(AnalysisDataset):
             raise_inversion_positions_likelihood_exception=raise_inversion_positions_likelihood_exception,
             title_prefix=title_prefix,
             use_jax=use_jax,
+            **kwargs,
         )
 
     @property


### PR DESCRIPTION
## Summary

PyAutoLens `AnalysisInterferometer.__init__` defined its own explicit signature without `**kwargs`, so any kwarg not in its named-parameter list (notably `use_jax_for_visualization` from the autofit base `Analysis`) raised `TypeError` instead of being forwarded to super.

This left `use_jax_for_visualization=True` silently unusable on `al.AnalysisInterferometer` despite:
- the interferometer visualizer dispatching via `fit_for_visualization` (`autolens/interferometer/model/visualizer.py:96, 209`, since #443)
- `AnalysisInterferometer` having full pytree registration via `_register_fit_interferometer_pytrees`

This PR adds `**kwargs` to the parameter list and forwards it in the `super().__init__()` call. `AnalysisDataset` (the parent) already accepts and forwards `**kwargs`, so this just plugs the gap in the subclass override. Compare `ag.AnalysisImaging` which has had `**kwargs` passthrough all along.

Discovered while drafting `interferometer/visualization_jax.py` and `interferometer/modeling_visualization_jit.py` for autolens_workspace_test (Phase 1A of the JAX visualization roadmap). The workspace_test scripts ship as a sibling PR on autolens_workspace_test, linked to PyAutoLabs/autolens_workspace_test#86.

## API Changes

`al.AnalysisInterferometer.__init__` gains a `**kwargs` passthrough — strictly additive. Any caller that previously worked is unaffected. New: callers can now pass `use_jax_for_visualization=True` (or any other kwarg accepted by the autofit base `Analysis`) without `TypeError`.

See full details below.

## Test Plan

- [x] `pytest test_autolens/imaging/ test_autolens/interferometer/ test_autolens/analysis/` — all pass
- [x] `python autolens_workspace_test/scripts/interferometer/visualization_jax.py` (with JAX enabled) — `PILOT SUCCEEDED — JAX-backed interferometer visualization produced fit.png/tracer.png.`
- [x] `python autolens_workspace_test/scripts/interferometer/modeling_visualization_jit.py` (with JAX enabled) — JIT cache fires during Nautilus, `fit.png` produced

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Signature

- `al.AnalysisInterferometer.__init__` now accepts `**kwargs` and forwards them to `super().__init__()`. Strictly additive — no existing call site is affected.

### Migration

None required. Callers that previously passed only the named arguments continue to work.

### Follow-ups not in this PR

- `al.AnalysisPoint.__init__` — same gap (no `**kwargs` passthrough). Deferred to Phase 1B of the JAX visualization roadmap (`PyAutoPrompt/issued/jax_viz_point_source_coverage.md`).
- `ag.AnalysisInterferometer.__init__` — same gap. Deferred to Phase 1C (`PyAutoPrompt/autogalaxy_workspace_test/jax_viz_dataset_coverage.md`).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)