### PR TITLE
fix: AnalysisPoint.__init__ kwargs passthrough

### DIFF
--- a/autolens/point/model/analysis.py
+++ b/autolens/point/model/analysis.py
@@ -43,6 +43,7 @@ class AnalysisPoint(AgAnalysis, AnalysisLens):
         cosmology: ag.cosmo.LensingCosmology = None,
         title_prefix: str = None,
         use_jax: bool = True,
+        **kwargs,
     ):
         """
         Fits a lens model to a point source dataset (e.g. positions, fluxes, time delays) via a non-linear search.
@@ -77,7 +78,7 @@ class AnalysisPoint(AgAnalysis, AnalysisLens):
             A string that is added before the title of all figures output by visualization, for example to
             put the name of the dataset and galaxy in the title.
         """
-        super().__init__(cosmology=cosmology, use_jax=use_jax)
+        super().__init__(cosmology=cosmology, use_jax=use_jax, **kwargs)
 
         AnalysisLens.__init__(self=self, cosmology=cosmology, use_jax=use_jax)
 


### PR DESCRIPTION
## Summary

PyAutoLens `AnalysisPoint.__init__` defined its own explicit signature without `**kwargs`, so any kwarg not in its named-parameter list (notably `use_jax_for_visualization` from the autofit base `Analysis`) raised `TypeError` instead of being forwarded to super.

This left `use_jax_for_visualization=True` silently unusable on `al.AnalysisPoint` despite:
- the point visualizer dispatching via `fit_for_visualization` (`autolens/point/model/visualizer.py:67`)
- being a direct mirror of the same gap fixed for `AnalysisInterferometer` in #500

This PR adds `**kwargs` to the parameter list and forwards it in the `super().__init__()` call. The `AgAnalysis` parent already accepts and forwards `**kwargs` (confirmed via #500's interferometer test plan), so this just plugs the gap in the subclass override.

Discovered during planning for autolens_workspace_test #90 (Phase 1B of the JAX visualization roadmap). The workspace_test scripts (`point_source/visualization.py` + `visualization_jax.py` + `modeling_visualization_jit.py`) ship as a sibling PR on autolens_workspace_test.

## API Changes

`al.AnalysisPoint.__init__` gains a `**kwargs` passthrough — strictly additive. Any caller that previously worked is unaffected. New: callers can now pass `use_jax_for_visualization=True` (or any other kwarg accepted by the autofit base `Analysis`) without `TypeError`.

See full details below.

## Test Plan

- [x] `pytest test_autolens/point/ test_autolens/analysis/` — all pass

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Signature

- `al.AnalysisPoint.__init__` now accepts `**kwargs` and forwards them to `super().__init__()`. Strictly additive — no existing call site is affected.

### Migration

None required. Callers that previously passed only the named arguments continue to work.

### Follow-ups not in this PR

- `ag.AnalysisInterferometer.__init__` — same `**kwargs` gap on the autogalaxy side. Deferred to Phase 1C of the JAX visualization roadmap (`PyAutoPrompt/autogalaxy_workspace_test/jax_viz_dataset_coverage.md`).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)