### PR TITLE
docs(api): list SersicMultipole and GaussianMultipole in autosummary

### DIFF
--- a/docs/api/light.rst
+++ b/docs/api/light.rst
@@ -14,8 +14,10 @@ Standard [``ag.lp``]
 
    Gaussian
    GaussianSph
+   GaussianMultipole
    Sersic
    SersicSph
+   SersicMultipole
    Exponential
    ExponentialSph
    DevVaucouleurs


### PR DESCRIPTION
## Summary

Docs-only follow-up to PyAutoLabs/PyAutoGalaxy#420 (which adds `SersicMultipole` and `GaussianMultipole` to `autogalaxy.profiles.light.standard`).

Since PyAutoLens re-exports that module as `lp`, the two new classes are accessible as `al.lp.SersicMultipole` and `al.lp.GaussianMultipole` without any code change here. This PR registers them in the Sphinx autosummary table under the Standard [`ag.lp`] section so they appear in the rendered lens docs alongside `Sersic`, `Gaussian`, etc.

## API Changes

None — pure documentation entries.

## Test Plan

- [x] `docs/api/light.rst` lists `SersicMultipole` and `GaussianMultipole` in the Standard section
- [x] `al.lp.SersicMultipole` and `al.lp.GaussianMultipole` resolve through the existing re-export at `autolens/__init__.py:78`

## Coordination

Merge after PyAutoLabs/PyAutoGalaxy#420 — the autosummary entries depend on the classes existing in the autogalaxy install picked up by ReadTheDocs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)