### PR TITLE
docs(api): sync light profile reference with PyAutoGalaxy

### DIFF
--- a/docs/api/light.rst
+++ b/docs/api/light.rst
@@ -5,6 +5,8 @@ Light Profiles
 Standard [``ag.lp``]
 --------------------
 
+Standard parametric light profiles whose ``intensity`` is a free parameter of the model.
+
 .. currentmodule:: autogalaxy.profiles.light.standard
 
 .. autosummary::
@@ -30,3 +32,68 @@ Standard [``ag.lp``]
    ChameleonSph
    ElsonFreeFall
    ElsonFreeFallSph
+
+Linear [``ag.lp_linear``]
+--------------------------
+
+Linear light profiles whose ``intensity`` is not a free parameter but is instead solved
+analytically via a linear matrix inversion during each likelihood evaluation.  This allows
+many profiles to be combined efficiently without exploding the non-linear parameter space.
+
+.. currentmodule:: autogalaxy.profiles.light.linear
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-class-template.rst
+   :recursive:
+
+   Gaussian
+   GaussianSph
+   GaussianMultipole
+   Sersic
+   SersicSph
+   SersicMultipole
+   Exponential
+   ExponentialSph
+   DevVaucouleurs
+   DevVaucouleursSph
+   SersicCore
+   SersicCoreSph
+   ExponentialCore
+   ExponentialCoreSph
+
+Operated [``ag.lp_operated``]
+------------------------------
+
+Operated light profiles that represent emission which has already had an instrument
+operation (e.g. PSF convolution) applied to it.  The ``operated_only`` parameter on
+fitting classes controls whether these profiles are included or excluded from a given
+image computation.
+
+.. currentmodule:: autogalaxy.profiles.light.operated
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-class-template.rst
+   :recursive:
+
+   Gaussian
+   Moffat
+   Sersic
+
+Basis [``ag.lp_basis``]
+------------------------
+
+A ``Basis`` groups a collection of light profiles (e.g. a Multi-Gaussian Expansion or
+shapelet decomposition) so that they behave as a single profile in the model.  When the
+constituent profiles are ``LightProfileLinear`` instances their intensities are all solved
+simultaneously via a single inversion.
+
+.. currentmodule:: autogalaxy.profiles.basis
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-class-template.rst
+   :recursive:
+
+   Basis


### PR DESCRIPTION
## Summary

Brings `docs/api/light.rst` into structural parity with PyAutoGalaxy's equivalent — adds
the previously missing `Linear [``ag.lp_linear``]`, `Operated [``ag.lp_operated``]`, and
`Basis [``ag.lp_basis``]` autosummary sections, and adds the one-line description to the
`Standard` section. After this PR the two files are byte-identical.

Motivation: the `SersicMultipole` / `GaussianMultipole` profiles merged via #515 (and the
upstream PyAutoGalaxy linear variants) are exposed on `al.lp_linear.*` but had no API
reference entry on the PyAutoLens docs site. Users browsing the autolens docs could not
discover the linear, operated, basis, or multipole-linear variants from the API page.

Part of #85 on `autogalaxy_workspace` — this is the library-side prerequisite before the
new `scripts/guides/profiles/light.py` is added to the two workspaces.

## API Changes

None — docs-only change. No Python code is modified, no symbols added or removed. The
new autosummary entries point at classes that already exist in
`autogalaxy.profiles.light.*` and are already re-exported by `autolens` as
`al.lp_linear`, `al.lp_operated`, `al.lp_basis`.
See full details below.

## Test Plan

- [ ] `docs/api/light.rst` and `PyAutoGalaxy/docs/api/light.rst` differ by zero bytes
- [ ] Existing PyAutoLens unit test suite still passes (no code touched, but pytest is a
  baseline sanity check)
- [ ] Optional: Sphinx build of the autolens docs produces no warnings for `light.rst`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `docs/api/light.rst` Linear section listing the 14 `ag.lp_linear` profiles documented
  in PyAutoGalaxy (including the newly merged `GaussianMultipole` and `SersicMultipole`
  linear variants)
- `docs/api/light.rst` Operated section listing `ag.lp_operated.Gaussian`, `Moffat`, `Sersic`
- `docs/api/light.rst` Basis section listing `ag.lp_basis.Basis`
- One-line description to the existing Standard section for consistency with PyAutoGalaxy

### Removed
- None

### Renamed
- None

### Changed Signature
- None

### Changed Behaviour
- None

### Migration
- None — purely additive docs change. No user-facing API affected.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)