### PR TITLE
feat: redesign subplot_fit panels — add Source Plane (Mid Zoom)

### DIFF
--- a/autolens/imaging/plot/fit_imaging_plots.py
+++ b/autolens/imaging/plot/fit_imaging_plots.py
@@ -98,7 +98,8 @@ from autolens.lens.plot.tracer_plots import plane_image_from
 
 def _plot_source_plane(fit, ax, plane_index, zoom_to_brightest=True,
                        colormap=None, use_log10=False, title=None,
-                       lines=None, line_colors=None, vmax=None):
+                       lines=None, line_colors=None, vmax=None,
+                       zoom_extent_scale: float = 1.0):
     """
     Plot the source-plane image (or a blank inversion placeholder) into an axes.
 
@@ -142,10 +143,20 @@ def _plot_source_plane(fit, ax, plane_index, zoom_to_brightest=True,
                 extent=zoom.extent_from(buffer=0),
                 shape_native=zoom.shape_native,
             )
+        zoom_extent_bounds = None
+        if zoom_extent_scale != 1.0:
+            zoom = aa.Zoom2D(mask=fit.mask)
+            no_zoom_grid = aa.Grid2D.from_extent(
+                extent=zoom.extent_from(buffer=0),
+                shape_native=zoom.shape_native,
+            )
+            zoom_extent_bounds = no_zoom_grid.geometry.extent
         image = plane_image_from(
             galaxies=tracer.planes[plane_index],
             grid=grid,
             zoom_to_brightest=zoom_to_brightest,
+            zoom_extent_scale=zoom_extent_scale,
+            zoom_extent_bounds=zoom_extent_bounds,
         )
         plot_array(
             array=image, ax=ax,
@@ -169,6 +180,7 @@ def _plot_source_plane(fit, ax, plane_index, zoom_to_brightest=True,
                 use_log10=use_log10,
                 vmax=vmax,
                 zoom_to_brightest=zoom_to_brightest,
+                zoom_extent_scale=zoom_extent_scale,
                 lines=lines,
                 line_colors=line_colors,
             )
@@ -196,13 +208,15 @@ def subplot_fit(
 
     Arranges the following panels in a 3 × 4 grid:
 
-    * Data (full scale and source scale)
-    * Signal-to-noise map
+    * Data
     * Model image
+    * Signal-to-noise map
+    * Source plane image (max zoom)
     * Lens-light model image
     * Lens-light-subtracted image (source scale)
     * Source model image (source scale)
-    * Source plane image (zoomed)
+    * Source plane image (mid zoom — 2× wider than max zoom, square, shrunk
+      uniformly so all edges stay inside the no-zoom extent)
     * Normalised residual map (symmetric scale)
     * Normalised residual map clipped to ± 1 σ
     * Chi-squared map
@@ -250,15 +264,18 @@ def subplot_fit(
 
     plot_array(array=fit.data, ax=axes_flat[0], title=_pf("Data"), colormap=colormap)
 
-    # Data at source scale
-    plot_array(array=fit.data, ax=axes_flat[1], title=_pf("Data (Source Scale)"),
-               colormap=colormap, vmax=source_vmax)
+    plot_array(array=fit.model_data, ax=axes_flat[1], title=_pf("Model Image"),
+               colormap=colormap, lines=image_plane_lines,
+               line_colors=image_plane_line_colors)
 
     plot_array(array=fit.signal_to_noise_map, ax=axes_flat[2],
                title=_pf("Signal-To-Noise Map"), colormap=colormap)
-    plot_array(array=fit.model_data, ax=axes_flat[3], title=_pf("Model Image"),
-               colormap=colormap, lines=image_plane_lines,
-               line_colors=image_plane_line_colors)
+
+    # Source plane (max zoom)
+    _plot_source_plane(fit, axes_flat[3], final_plane_index, zoom_to_brightest=True,
+                       colormap=colormap, title=_pf("Source Plane (Max Zoom)"),
+                       lines=source_plane_lines, line_colors=source_plane_line_colors,
+                       vmax=source_vmax)
 
     # Lens model image
     try:
@@ -295,11 +312,11 @@ def subplot_fit(
     else:
         axes_flat[6].axis("off")
 
-    # Source plane zoomed
+    # Source plane (mid zoom) — same centre as Max Zoom, 2.5x wider extent
     _plot_source_plane(fit, axes_flat[7], final_plane_index, zoom_to_brightest=True,
-                       colormap=colormap, title=_pf("Source Plane (Zoomed)"),
+                       colormap=colormap, title=_pf("Source Plane (Mid Zoom)"),
                        lines=source_plane_lines, line_colors=source_plane_line_colors,
-                       vmax=source_vmax)
+                       vmax=source_vmax, zoom_extent_scale=2.0)
 
     # Normalized residual map (symmetric)
     norm_resid = fit.normalized_residual_map
@@ -411,7 +428,10 @@ def subplot_fit_log10(
     positive-valued panels (data, model image, lens-light model, subtracted
     image, source model image, chi-squared map, source plane images).
     Residual panels are left on a linear scale because they contain negative
-    values.
+    values.  Includes Source Plane (Max Zoom) and Source Plane (Mid Zoom)
+    panels — Mid Zoom shares the Max Zoom centre with extents 2x larger,
+    kept square and shrunk uniformly so all edges stay inside the No Zoom
+    extent.
 
     For single-plane tracers the function delegates to
     :func:`subplot_fit_log10_x1_plane`.
@@ -455,11 +475,9 @@ def subplot_fit_log10(
     plot_array(array=fit.data, ax=axes_flat[0], title=_pf("Data"), colormap=colormap,
                use_log10=True)
 
-    try:
-        plot_array(array=fit.data, ax=axes_flat[1], title=_pf("Data (Source Scale)"),
-                   colormap=colormap, use_log10=True)
-    except ValueError:
-        axes_flat[1].axis("off")
+    plot_array(array=fit.model_data, ax=axes_flat[1], title=_pf("Model Image"),
+               colormap=colormap, use_log10=True, lines=image_plane_lines,
+               line_colors=image_plane_line_colors)
 
     try:
         plot_array(array=fit.signal_to_noise_map, ax=axes_flat[2],
@@ -467,9 +485,12 @@ def subplot_fit_log10(
     except ValueError:
         axes_flat[2].axis("off")
 
-    plot_array(array=fit.model_data, ax=axes_flat[3], title=_pf("Model Image"),
-               colormap=colormap, use_log10=True, lines=image_plane_lines,
-               line_colors=image_plane_line_colors)
+    # Source plane (max zoom)
+    _plot_source_plane(fit, axes_flat[3], final_plane_index, zoom_to_brightest=True,
+                       colormap=colormap, use_log10=True,
+                       title=_pf("Source Plane (Max Zoom)"),
+                       lines=source_plane_lines, line_colors=source_plane_line_colors,
+                       vmax=source_vmax)
 
     try:
         lens_model_img = fit.model_images_of_planes_list[0]
@@ -493,11 +514,12 @@ def subplot_fit_log10(
     except (IndexError, AttributeError):
         axes_flat[6].axis("off")
 
+    # Source plane (mid zoom) — same centre as Max Zoom, 2.5x wider extent
     _plot_source_plane(fit, axes_flat[7], final_plane_index, zoom_to_brightest=True,
                        colormap=colormap, use_log10=True,
-                       title=_pf("Source Plane (Zoomed)"),
+                       title=_pf("Source Plane (Mid Zoom)"),
                        lines=source_plane_lines, line_colors=source_plane_line_colors,
-                       vmax=source_vmax)
+                       vmax=source_vmax, zoom_extent_scale=2.0)
 
     norm_resid = fit.normalized_residual_map
     _abs_max = _symmetric_vmax(norm_resid)

--- a/autolens/lens/plot/tracer_plots.py
+++ b/autolens/lens/plot/tracer_plots.py
@@ -14,6 +14,8 @@ def plane_image_from(
     grid: aa.Grid2D,
     buffer: float = 1.0e-2,
     zoom_to_brightest: bool = True,
+    zoom_extent_scale: float = 1.0,
+    zoom_extent_bounds: Optional[tuple] = None,
 ) -> aa.Array2D:
     """
     Return the unlensed source-plane image of a list of galaxies.
@@ -79,6 +81,34 @@ def plane_image_from(
                 grid_native[y_max_pix, 0][0] + buffer,
             )
             extent = aa.util.geometry.extent_symmetric_from(extent=extent)
+
+            if zoom_extent_scale != 1.0:
+                x_min, x_max, y_min, y_max = extent
+                x_centre = 0.5 * (x_min + x_max)
+                y_centre = 0.5 * (y_min + y_max)
+                target_half = 0.5 * max(x_max - x_min, y_max - y_min) * zoom_extent_scale
+
+                if zoom_extent_bounds is not None:
+                    max_allowable_half = min(
+                        x_centre - zoom_extent_bounds[0],
+                        zoom_extent_bounds[1] - x_centre,
+                        y_centre - zoom_extent_bounds[2],
+                        zoom_extent_bounds[3] - y_centre,
+                    )
+                    bound_cap_half = 0.7 * 0.5 * min(
+                        zoom_extent_bounds[1] - zoom_extent_bounds[0],
+                        zoom_extent_bounds[3] - zoom_extent_bounds[2],
+                    )
+                    final_half = min(target_half, max_allowable_half, bound_cap_half)
+                else:
+                    final_half = target_half
+
+                extent = (
+                    x_centre - final_half,
+                    x_centre + final_half,
+                    y_centre - final_half,
+                    y_centre + final_half,
+                )
 
             pixel_scales = (
                 float((extent[3] - extent[2]) / shape[0]),

--- a/test_autolens/imaging/plot/test_fit_imaging_plots.py
+++ b/test_autolens/imaging/plot/test_fit_imaging_plots.py
@@ -32,6 +32,17 @@ def test__subplot_fit__two_plane_tracer__output_file_created(
     assert str(plot_path / "fit.png") in plot_patch.paths
 
 
+def test__subplot_fit__inversion_source__mid_zoom_panel_renders(
+    fit_imaging_x2_plane_inversion_7x7, plot_path, plot_patch
+):
+    subplot_fit(
+        fit=fit_imaging_x2_plane_inversion_7x7,
+        output_path=plot_path,
+        output_format="png",
+    )
+    assert str(plot_path / "fit.png") in plot_patch.paths
+
+
 def test__subplot_fit__single_plane_tracer__delegates_to_x1_plane_and_creates_file(
     fit_imaging_x1_plane_7x7, plot_path, plot_patch
 ):


### PR DESCRIPTION
## Summary
Reshuffles the 12-panel `subplot_fit` (and `subplot_fit_log10`) layout: drops the near-useless "Data (Source Scale)" panel, moves "Model Image" beside "Data", promotes the zoomed source plane to the top right and renames it "Source Plane (Max Zoom)", and adds a new "Source Plane (Mid Zoom)" panel — same centre as Max Zoom but with extents 2× larger, kept square and shrunk so it always sits inside the No Zoom extent (no edge exceeds, and at most 70% of the No Zoom half-width).

**Blocked by:** the corresponding PyAutoArray PR (adds `zoom_extent_scale` to `plot_mapper` / `Mapper.extent_from`). That must merge first or this PR's tests will fail against released PyAutoArray.

## API Changes
- `_plot_source_plane(...)` and `plane_image_from(...)` gain a `zoom_extent_scale` kwarg. `plane_image_from` also gains a `zoom_extent_bounds` kwarg.
- `subplot_fit` and `subplot_fit_log10` produce the new 12-panel layout — same panel count, different ordering, one renamed panel ("Source Plane (Zoomed)" → "Source Plane (Max Zoom)"), one new panel ("Source Plane (Mid Zoom)"), one removed panel ("Data (Source Scale)").

See full details below.

## Test Plan
- [x] `python -m pytest test_autolens/imaging/plot test_autolens/lens/plot -x` passes
- [x] `autolens_workspace_test/scripts/imaging/visualization.py` runs cleanly for parametric, rectangular, and delaunay source types
- [x] Visual inspection of all three rendered `fit.png` files confirms Mid Zoom panel sits between Max Zoom and No Zoom

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `_plot_source_plane(..., zoom_extent_scale=1.0)` — new optional kwarg, forwarded to `plane_image_from` (parametric) and `plot_mapper` (inversion).
- `plane_image_from(..., zoom_extent_scale=1.0, zoom_extent_bounds=None)` — new optional kwargs. When `zoom_extent_scale > 1.0`, scales the brightest-region extent by that factor about its centre; when `zoom_extent_bounds` is provided, the result is clamped so all edges stay inside that bound (kept square via a uniform shrink).

### Changed Behaviour
- `subplot_fit` panel layout changed (panel count unchanged):
  - idx 1 (row 0 col 1): was "Data (Source Scale)" → now "Model Image"
  - idx 3 (row 0 col 3): was "Model Image" → now "Source Plane (Max Zoom)" (renamed from "Source Plane (Zoomed)")
  - idx 7 (row 1 col 3): was "Source Plane (Zoomed)" → now new "Source Plane (Mid Zoom)" panel
  - The "Data (Source Scale)" panel is removed.
- `subplot_fit_log10` mirrors the same reshuffle.

### Migration
None — both functions retain their existing signatures and produce a 3×4 grid of panels. Scripts that referenced panels by index will see a different image at the same index; scripts that referenced panels by title will need to use the new titles ("Source Plane (Max Zoom)" and "Source Plane (Mid Zoom)").

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)