### PR TITLE
docs(api): sync mass.rst with full al.mp namespace + lmp / lmp_linear

### DIFF
--- a/docs/api/mass.rst
+++ b/docs/api/mass.rst
@@ -12,7 +12,6 @@ Total [ag.mp]
    :template: custom-class-template.rst
    :recursive:
 
-   PointMass
    PowerLawCore
    PowerLawCoreSph
    PowerLawBroken
@@ -23,6 +22,11 @@ Total [ag.mp]
    PowerLawSph
    Isothermal
    IsothermalSph
+   dPIEMass
+   dPIEMassSph
+   PIEMass
+   dPIEPotential
+   dPIEPotentialSph
 
 Mass Sheets [ag.mp]
 -------------------
@@ -35,6 +39,7 @@ Mass Sheets [ag.mp]
    :recursive:
 
    ExternalShear
+   ExternalPotential
    MassSheet
 
 Multipoles [ag.mp]
@@ -49,6 +54,20 @@ Multipoles [ag.mp]
 
    PowerLawMultipole
 
+Point Mass [ag.mp]
+------------------
+
+.. currentmodule:: autogalaxy.profiles.mass
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-class-template.rst
+   :recursive:
+
+   PointMass
+   SMBH
+   SMBHBinary
+
 Stellar [ag.mp]
 ---------------
 
@@ -60,8 +79,11 @@ Stellar [ag.mp]
    :recursive:
 
    Gaussian
+   GaussianGradient
    Sersic
    SersicSph
+   SersicCore
+   SersicCoreSph
    Exponential
    ExponentialSph
    DevVaucouleurs
@@ -83,15 +105,85 @@ Dark [ag.mp]
 
    gNFW
    gNFWSph
+   gNFWMCRLudlow
+   gNFWVirialMassConcSph
+   gNFWVirialMassgNFWConcSph
+   NFW
+   NFWSph
+   NFWMCRDuffySph
+   NFWMCRLudlow
+   NFWMCRLudlowSph
+   NFWMCRScatterLudlow
+   NFWMCRScatterLudlowSph
+   NFWVirialMassConcSph
    NFWTruncatedSph
    NFWTruncatedMCRDuffySph
    NFWTruncatedMCRLudlowSph
    NFWTruncatedMCRScatterLudlowSph
-   NFW
-   NFWSph
-   NFWMCRDuffySph
-   NFWMCRLudlowSph
-   NFWMCRScatterLudlow
-   NFWMCRScatterLudlowSph
-   NFWMCRLudlow
-   gNFWMCRLudlow
+   cNFW
+   cNFWSph
+   cNFWMCRLudlow
+   cNFWMCRLudlowSph
+   cNFWMCRScatterLudlow
+   cNFWMCRScatterLudlowSph
+
+Stellar Light+Mass [ag.lmp]
+---------------------------
+
+Combined light-and-mass profiles whose ``image_2d_from`` and ``convergence_2d_from`` share
+a single parametric shape via a ``mass_to_light_ratio`` parameter.
+
+.. currentmodule:: autogalaxy.profiles.light_and_mass_profiles
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-class-template.rst
+   :recursive:
+
+   Gaussian
+   GaussianGradient
+   Sersic
+   SersicSph
+   SersicCore
+   SersicCoreSph
+   SersicGradient
+   SersicGradientSph
+   Exponential
+   ExponentialSph
+   ExponentialGradient
+   ExponentialGradientSph
+   DevVaucouleurs
+   DevVaucouleursSph
+   Chameleon
+   ChameleonSph
+
+Linear Light+Mass [ag.lmp_linear]
+---------------------------------
+
+The inversion-aware variants of ``ag.lmp.*`` — same parametric shapes and
+``mass_to_light_ratio`` semantics, with ``intensity`` solved analytically via the linear
+inversion during each likelihood evaluation rather than as a free non-linear parameter.
+
+.. currentmodule:: autogalaxy.profiles.light_linear_and_mass_profiles
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-class-template.rst
+   :recursive:
+
+   Gaussian
+   GaussianGradient
+   Sersic
+   SersicSph
+   SersicCore
+   SersicCoreSph
+   SersicGradient
+   SersicGradientSph
+   Exponential
+   ExponentialSph
+   ExponentialGradient
+   ExponentialGradientSph
+   DevVaucouleurs
+   DevVaucouleursSph
+   Chameleon
+   ChameleonSph


### PR DESCRIPTION
## Summary

`docs/api/mass.rst` was out of sync with the `al.mp.*` namespace it documents — multiple
exported classes were missing from the autosummary, and the `al.lmp.*` / `al.lmp_linear.*`
namespaces had no autosummary entries at all. This PR brings the file in line with the
current namespace.

Motivation: surfaced as a follow-up while writing the
`scripts/guides/profiles/mass.py` (autolens_workspace #178 / #179) and
`scripts/guides/profiles/light_and_mass_profiles.py` (autolens_workspace #180 / #181)
guides — both reference the published API reference URL, so the reference itself should
list every class the guides demonstrate.

Closes #519.

## API Changes

None — docs-only change. No Python code is modified, no symbols added or removed. The new
autosummary entries point at classes that already exist in `autogalaxy.profiles.mass.*`,
`autogalaxy.profiles.light_and_mass_profiles`, and
`autogalaxy.profiles.light_linear_and_mass_profiles`, and are already re-exported by
`autolens` as `al.mp.*`, `al.lmp.*`, and `al.lmp_linear.*`.
See full details below.

## Test Plan

- [ ] PyAutoLens unit test suite passes (no code touched, but pytest is a baseline sanity check)
- [ ] Sphinx build of the autolens docs produces no warnings for `mass.rst`
- [ ] Spot-check the rendered autosummary against `dir(al.mp)`, `dir(al.lmp)`, `dir(al.lmp_linear)`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added (autosummary entries)
- **Total `[ag.mp]`** — `dPIEMass`, `dPIEMassSph`, `PIEMass`, `dPIEPotential`, `dPIEPotentialSph`
- **Mass Sheets `[ag.mp]`** — `ExternalPotential`
- **Stellar `[ag.mp]`** — `GaussianGradient`, `SersicCore`, `SersicCoreSph`
- **Dark `[ag.mp]`** — `cNFW`, `cNFWSph`, `cNFWMCRLudlow`, `cNFWMCRLudlowSph`, `cNFWMCRScatterLudlow`, `cNFWMCRScatterLudlowSph`, `gNFWVirialMassConcSph`, `gNFWVirialMassgNFWConcSph`, `NFWVirialMassConcSph`
- **New section — Point Mass `[ag.mp]`** — `PointMass`, `SMBH`, `SMBHBinary`
- **New section — Stellar Light+Mass `[ag.lmp]`** — every class in `autogalaxy.profiles.light_and_mass_profiles` (Gaussian, GaussianGradient, Sersic, SersicSph, SersicCore, SersicCoreSph, SersicGradient, SersicGradientSph, Exponential, ExponentialSph, ExponentialGradient, ExponentialGradientSph, DevVaucouleurs, DevVaucouleursSph, Chameleon, ChameleonSph)
- **New section — Linear Light+Mass `[ag.lmp_linear]`** — same class list as `ag.lmp`

### Moved
- `PointMass` moved from `Total [ag.mp]` to the new `Point Mass [ag.mp]` section so the point-mass family (with SMBH / SMBHBinary) lives together.

### Removed
- None

### Renamed
- None

### Changed Signature / Changed Behaviour / Migration
- None — purely additive docs change. No user-facing API affected.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)