### PR TITLE
feat: re-export galaxy_model_csv helpers under al.*

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -63,6 +63,12 @@ from autogalaxy.galaxy.galaxies import Galaxies
 from autogalaxy.galaxy.galaxy_table import GalaxyTable
 from autogalaxy.galaxy.galaxy_table import galaxy_table_from_csv
 from autogalaxy.galaxy.galaxy_table import galaxy_table_to_csv
+from autogalaxy.galaxy.galaxy_model_csv import GalaxyModelRow
+from autogalaxy.galaxy.galaxy_model_csv import GalaxyModelTable
+from autogalaxy.galaxy.galaxy_model_csv import galaxy_models_from_csv
+from autogalaxy.galaxy.galaxy_model_csv import galaxy_models_to_csv
+from autogalaxy.galaxy.galaxy_model_csv import galaxies_from_csv_tables
+from autogalaxy.galaxy.galaxy_model_csv import galaxy_af_models_from_csv_tables
 from autogalaxy.galaxy.redshift import Redshift
 
 from autogalaxy.quantity.dataset_quantity import DatasetQuantity

--- a/test_autolens/test_csv_reexports.py
+++ b/test_autolens/test_csv_reexports.py
@@ -1,0 +1,11 @@
+"""Sanity check that the new galaxy_model_csv helpers are re-exported under al.*."""
+import autolens as al
+
+
+def test__al_namespace_exposes_galaxy_model_csv_helpers():
+    assert callable(al.galaxy_models_from_csv)
+    assert callable(al.galaxy_models_to_csv)
+    assert callable(al.galaxies_from_csv_tables)
+    assert callable(al.galaxy_af_models_from_csv_tables)
+    assert al.GalaxyModelRow.__name__ == "GalaxyModelRow"
+    assert al.GalaxyModelTable.__name__ == "GalaxyModelTable"


### PR DESCRIPTION
## Summary

Companion PR to https://github.com/PyAutoLabs/PyAutoGalaxy/pull/428. Re-exports the new named-galaxy CSV helpers under `al.*` so workspace scripts can use the canonical `import autolens as al` pattern.

Depends on the PyAutoGalaxy PR landing first.

## API Changes

Six new re-exports: `al.GalaxyModelRow`, `al.GalaxyModelTable`, `al.galaxy_models_from_csv`, `al.galaxy_models_to_csv`, `al.galaxies_from_csv_tables`, `al.galaxy_af_models_from_csv_tables`. All point to the corresponding `autogalaxy.galaxy.galaxy_model_csv` symbols. See the upstream PyAutoGalaxy PR for the helper docs.

See full details below.

## Test Plan

- [x] `pytest test_autolens/test_csv_reexports.py` — sanity test that confirms each new symbol is reachable via `al.*` and callable.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added (re-exports only)

- `autolens.GalaxyModelRow` — re-export of `autogalaxy.GalaxyModelRow`.
- `autolens.GalaxyModelTable` — re-export of `autogalaxy.GalaxyModelTable`.
- `autolens.galaxy_models_from_csv` — re-export of `autogalaxy.galaxy_models_from_csv`.
- `autolens.galaxy_models_to_csv` — re-export of `autogalaxy.galaxy_models_to_csv`.
- `autolens.galaxies_from_csv_tables` — re-export of `autogalaxy.galaxies_from_csv_tables`.
- `autolens.galaxy_af_models_from_csv_tables` — re-export of `autogalaxy.galaxy_af_models_from_csv_tables`.

No new logic in PyAutoLens.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)