### PR TITLE
fix(viz): make _compute_critical_curve_lines failures loud, not silent

### DIFF
--- a/autolens/imaging/plot/fit_imaging_plots.py
+++ b/autolens/imaging/plot/fit_imaging_plots.py
@@ -49,7 +49,22 @@ def _compute_critical_curve_lines(tracer, grid):
             ["white"] * len(_tan_ca_lines) + ["yellow"] * len(_rad_ca_lines)
         )
         return image_plane_lines, image_plane_line_colors, source_plane_lines, source_plane_line_colors
+    except (ModuleNotFoundError, ValueError):
+        # ModuleNotFoundError: jax_zero_contour missing — already warned upstream in
+        # plot_utils._critical_curves_method().
+        # ValueError: no zero crossings in the eigenvalue grid (e.g. slope >= 2
+        # isothermal where lambda_r > 0 everywhere). Curves don't exist for this
+        # model, so rendering without overlays is correct.
+        return None, None, None, None
     except Exception:
+        # Anything else — log loudly with traceback so the next regression of the
+        # "ZeroSolver raised inside model-fit, viz fell back to all-zero" failure
+        # mode (PyAutoGalaxy abd7b717, PyAutoFit #1280) does not stay silent.
+        logger.warning(
+            "Critical-curve computation failed unexpectedly; rendering without "
+            "overlays. Investigate — this used to be a silent fallback.",
+            exc_info=True,
+        )
         return None, None, None, None
 
 

--- a/test_autolens/imaging/plot/test_fit_imaging_plots.py
+++ b/test_autolens/imaging/plot/test_fit_imaging_plots.py
@@ -1,8 +1,11 @@
+import logging
 from pathlib import Path
 
 import pytest
 
+from autolens.imaging.plot import fit_imaging_plots
 from autolens.imaging.plot.fit_imaging_plots import (
+    _compute_critical_curve_lines,
     subplot_fit,
     subplot_fit_log10,
     subplot_fit_x1_plane,
@@ -156,3 +159,58 @@ def test__subplot_fit_combined_log10__list_of_two_fits__output_file_created(
         output_format="png",
     )
     assert str(plot_path / "fit_combined_log10.png") in plot_patch.paths
+
+
+@pytest.mark.parametrize(
+    "exc_cls",
+    [ModuleNotFoundError, ValueError],
+    ids=["jax_zero_contour_missing", "no_zero_crossings"],
+)
+def test__compute_critical_curve_lines__known_recoverable_exceptions__silent(
+    monkeypatch, caplog, exc_cls
+):
+    """
+    Two failure modes are expected and pre-handled upstream: ``jax_zero_contour``
+    not installed (``ModuleNotFoundError``) and a model with no zero crossings
+    (``ValueError`` raised by ``_init_guess_from_coarse_grid``). These must
+    fall through silently — no WARNING log — so plot-time noise stays clean
+    when the absence of critical curves is the correct rendering.
+    """
+    def boom(*args, **kwargs):
+        raise exc_cls("synthetic failure for test")
+
+    monkeypatch.setattr(fit_imaging_plots, "_critical_curves_from", boom)
+
+    with caplog.at_level(logging.WARNING, logger=fit_imaging_plots.__name__):
+        result = _compute_critical_curve_lines(tracer=None, grid=None)
+
+    assert result == (None, None, None, None)
+    assert caplog.records == [], (
+        "known-recoverable failure must not emit a WARNING log"
+    )
+
+
+def test__compute_critical_curve_lines__unexpected_exception__logs_warning(
+    monkeypatch, caplog
+):
+    """
+    Anything OTHER than ``ModuleNotFoundError`` / ``ValueError`` is treated as
+    an unexpected failure (the silent failure mode that caused the
+    2026-04-19 PyAutoGalaxy zero_contour revert and the 2026-05-16 Euclid
+    pipeline regression). Such failures must surface as a WARNING log with
+    a traceback — never silently swallowed.
+    """
+    def boom(*args, **kwargs):
+        raise RuntimeError("synthetic unexpected failure for test")
+
+    monkeypatch.setattr(fit_imaging_plots, "_critical_curves_from", boom)
+
+    with caplog.at_level(logging.WARNING, logger=fit_imaging_plots.__name__):
+        result = _compute_critical_curve_lines(tracer=None, grid=None)
+
+    assert result == (None, None, None, None)
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelno == logging.WARNING
+    assert record.exc_info is not None, "traceback must be attached"
+    assert isinstance(record.exc_info[1], RuntimeError)


### PR DESCRIPTION
## Summary

Tightens the broad `except Exception:` in `_compute_critical_curve_lines` so future regressions of the "ZeroSolver raised, viz fell back to all-zero" failure mode fail loud, not silent.

Two recent reverts share the same shape — a JAX-tracing failure inside the visualization path that the broad except masked into `(None, None, None, None)`:

- **2026-04-19** — PyAutoGalaxy commit `abd7b717` reverted the YAML default flip to `zero_contour`. Critical curves silently vanished on HPC runs.
- **2026-05-17** — PyAutoFit PR #1280 reverted the `use_jax_for_visualization=True` default. Source-plane FITS files wrote all-zero across every Euclid DR1 tile and Einstein-radius posteriors collapsed to the full prior.

Both were invisible at run time. The next attempt to flip the default needs a loud failure if it regresses, so this PR:

- Keeps `ModuleNotFoundError` silent (the `jax_zero_contour` absence is already warned upstream in `plot_utils._critical_curves_method`).
- Keeps `ValueError` silent (no zero crossings in the eigenvalue grid — curves genuinely don't exist for the model).
- Logs anything else as `WARNING` with `exc_info=True` via the module logger, then still returns the no-overlay tuple so plotting itself doesn't crash.

Companion PR in PyAutoGalaxy (`Jammy2211/PyAutoGalaxy#434`) fixes the underlying perf bug that made `zero_contour` unusable as a default.

Closes Jammy2211/PyAutoGalaxy#433 (alongside the PyAutoGalaxy companion).

## API Changes

`_compute_critical_curve_lines` is a private helper — no public API surface changes. Behavioural change: unexpected exceptions now emit a `WARNING` log with traceback before falling back to no-overlay rendering, instead of being silently swallowed.

See full details below.

## Test Plan

- [x] New parametrized test `test__compute_critical_curve_lines__known_recoverable_exceptions__silent` — confirms `ModuleNotFoundError` and `ValueError` fall through with no log record emitted.
- [x] New test `test__compute_critical_curve_lines__unexpected_exception__logs_warning` — confirms an unexpected `RuntimeError` produces exactly one `WARNING` record with `exc_info` attached.
- [x] `pytest test_autolens/imaging/plot/` — 15 passed locally.
- [x] `autolens_workspace_test/scripts/imaging/modeling_visualization_jit.py` Part 1 + Visualization Sanity block run cleanly under the new exception flow.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- None public.

### Changed Signature
- None.

### Changed Behaviour
- `autolens.imaging.plot.fit_imaging_plots._compute_critical_curve_lines` — replaces bare `except Exception:` with specific catches. `ModuleNotFoundError` and `ValueError` still fall through silently; anything else logs `WARNING` with traceback via the module logger before returning the no-overlay tuple.

### Migration
- None required. Downstream callers that previously relied on the silent fallback still get the same return value `(None, None, None, None)`; they additionally see a WARNING log when an unexpected failure occurs.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)