### PR TITLE
fix: total_source_flux_mujy wrong value for linear light profiles

### DIFF
--- a/autolens/analysis/latent.py
+++ b/autolens/analysis/latent.py
@@ -76,12 +76,18 @@ def total_lensed_source_flux_mujy(fit, magzero, xp=np):
 
 def total_source_flux_mujy(fit, magzero, xp=np):
     """
-    Source-plane intrinsic flux of the source galaxy, via
-    ``fit.tracer.galaxies[-1].image_2d_from(grid=fit.dataset.grids.lp)``.
+    Source-plane intrinsic flux of the source galaxy, in microjanskies.
+
+    Reads from ``fit.tracer_linear_light_profiles_to_light_profiles`` rather
+    than ``fit.tracer`` so that linear light profiles (whose ``intensity``
+    is solved by the inversion at fit time) contribute the correct image.
+    For non-linear fits this property is a no-op pass-through (returns
+    ``fit.tracer``), so the numpy-only and JAX paths both work uniformly.
     """
     _require_magzero(magzero, "total_source_flux_mujy")
     try:
-        source_image = fit.tracer.galaxies[-1].image_2d_from(
+        tracer = fit.tracer_linear_light_profiles_to_light_profiles
+        source_image = tracer.galaxies[-1].image_2d_from(
             grid=fit.dataset.grids.lp, xp=xp
         )
     except (AttributeError, IndexError):

--- a/test_autolens/analysis/test_latent.py
+++ b/test_autolens/analysis/test_latent.py
@@ -82,8 +82,13 @@ def test_total_source_flux_mujy_against_known_image():
             array=np.array([2.0, 3.0, 5.0])
         )
     )
+    # Both `tracer` and `tracer_linear_light_profiles_to_light_profiles`
+    # point at the same galaxies for non-linear fits — the conversion
+    # property is a no-op pass-through.
+    galaxies_namespace = SimpleNamespace(galaxies=[object(), source])
     fit = SimpleNamespace(
-        tracer=SimpleNamespace(galaxies=[object(), source]),
+        tracer=galaxies_namespace,
+        tracer_linear_light_profiles_to_light_profiles=galaxies_namespace,
         dataset=SimpleNamespace(grids=SimpleNamespace(lp=object())),
     )
     value = total_source_flux_mujy(fit=fit, magzero=25.0)
@@ -91,6 +96,38 @@ def test_total_source_flux_mujy_against_known_image():
     expected_ab_mag = -2.5 * np.log10(10.0) + 25.0
     expected_muJy = 10 ** ((23.9 - expected_ab_mag) / 2.5)
     assert value == pytest.approx(expected_muJy)
+
+
+def test_total_source_flux_mujy_uses_converted_tracer_for_linear_profiles():
+    """When the source has a linear light profile, ``fit.tracer.galaxies[-1]``
+    is un-solved (``image_2d_from`` returns zeros). The library must read from
+    ``fit.tracer_linear_light_profiles_to_light_profiles`` where intensities
+    are filled in from the inversion."""
+
+    unsolved_source = SimpleNamespace(
+        image_2d_from=lambda grid, xp=np: SimpleNamespace(array=np.zeros(4))
+    )
+    solved_source = SimpleNamespace(
+        image_2d_from=lambda grid, xp=np: SimpleNamespace(
+            array=np.array([1.0, 2.0, 3.0, 4.0])
+        )
+    )
+    fit = SimpleNamespace(
+        tracer=SimpleNamespace(galaxies=[object(), unsolved_source]),
+        tracer_linear_light_profiles_to_light_profiles=SimpleNamespace(
+            galaxies=[object(), solved_source]
+        ),
+        dataset=SimpleNamespace(grids=SimpleNamespace(lp=object())),
+    )
+
+    value = total_source_flux_mujy(fit=fit, magzero=25.0)
+
+    # Expected from the solved source (sum = 10):
+    expected_ab_mag = -2.5 * np.log10(10.0) + 25.0
+    expected_muJy = 10 ** ((23.9 - expected_ab_mag) / 2.5)
+    assert value == pytest.approx(expected_muJy)
+    # Confirm we did NOT read from the unsolved tracer (which would give 0).
+    assert value != 0.0
 
 
 def test_total_source_flux_mujy_missing_magzero_raises():
@@ -108,8 +145,12 @@ def test_magnification_is_lensed_over_intrinsic():
             return SimpleNamespace(array=np.array([2.0]))
 
     source = _FakeSourceGalaxy()
+    # Same fakes for tracer and the converted-tracer property (no-op
+    # pass-through for non-linear profile fixtures).
+    galaxies_namespace = SimpleNamespace(galaxies=[object(), source])
     fit = SimpleNamespace(
-        tracer=SimpleNamespace(galaxies=[object(), source]),
+        tracer=galaxies_namespace,
+        tracer_linear_light_profiles_to_light_profiles=galaxies_namespace,
         galaxy_image_dict={source: SimpleNamespace(array=np.array([10.0]))},
         dataset=SimpleNamespace(grids=SimpleNamespace(lp=object())),
     )


### PR DESCRIPTION
## Summary

`total_source_flux_mujy` (shipped in #534) returns wrong values for fits using linear light profiles (any `lp_linear.*` or MGE basis). For linear profiles `fit.tracer.galaxies[-1]` carries unsolved profiles — `image_2d_from` returns zeros because intensities are filled by the inversion at fit time, not propagated back into the source-plane profile objects. `magnification` inherits the bug via its source-flux denominator.

Fix: read from `fit.tracer_linear_light_profiles_to_light_profiles` (which rebuilds the tracer with intensities filled in from the inversion). For non-linear fits this property short-circuits to `self.model_obj` — pure no-op pass-through, no behaviour change.

Discovered while planning the Euclid pipeline migration (PyAutoLabs/euclid_strong_lens_modeling_pipeline#17). Euclid had already coded the workaround locally at `util.py:378` — this PR lifts it into the library so other lens projects with linear profiles get correct values without each one re-discovering the issue.

Closes #535.

## API Changes

None — internal change only. Function signatures, registry keys, config layout, and `AnalysisImaging` wiring are all unchanged. Only the body of `total_source_flux_mujy` is modified (one extra attribute access). `magnification` automatically returns correct values via the fix.

## Test Plan

- [x] `pytest test_autolens/analysis/test_latent.py -x -v` — 18/18 pass (including the new `test_total_source_flux_mujy_uses_converted_tracer_for_linear_profiles`).
- [x] `pytest test_autolens/` — 312/312 pass (no regression).
- [x] Empirical JIT-path validation: euclid uses this exact pattern (`util.py:378`) under `LATENT_BATCH_MODE = "jit"` in production.

<details>
<summary>Stress-test notes</summary>

**Why the fix is safe:**

1. **Non-linear fits**: `autogalaxy/abstract_fit.py:214` — `model_obj_linear_light_profiles_to_light_profiles` early-returns `self.model_obj` when `linear_light_profile_intensity_dict is None`. Pure pass-through.

2. **Linear-profile fits**: `append_linear_light_profiles_to_model(...)` rebuilds the tracer with intensities filled in. The intensity dict is populated as a side-effect of the inversion that already runs to produce `figure_of_merit` — no extra inversion solve.

3. **JIT path**: euclid empirically validates this — `util.py:378` runs under JIT in production. The property's Python branches (`if linear_light_profile_intensity_dict is None`) are structural (static across samples), so JAX traces them cleanly.

4. **`total_lens_flux_mujy` / `total_lensed_source_flux_mujy` are unchanged**: they read `fit.galaxy_image_dict[...]` which already merges `galaxy_linear_obj_data_dict_from` for linear-obj galaxies via `FitImaging.galaxy_image_dict`. Correct for both linear and non-linear.

5. **`effective_einstein_radius` is unchanged**: light-profile-independent (depends on mass model only).

6. **Performance**: O(1) attribute access for non-linear fits; one tracer rebuild per `compute_latent_variables` call for linear fits. Inside JIT, the rebuild is traced once and reused per sample.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
