### PR TITLE
feat: SimulatorImaging.via_tracer_from auto-default xp from parent use_jax

### DIFF
--- a/autolens/imaging/simulator.py
+++ b/autolens/imaging/simulator.py
@@ -22,7 +22,7 @@ from autolens.lens.tracer import Tracer
 
 class SimulatorImaging(aa.SimulatorImaging):
 
-    def via_tracer_from(self, tracer : Tracer, grid : aa.type.Grid2DLike, xp=np) -> aa.Imaging:
+    def via_tracer_from(self, tracer : Tracer, grid : aa.type.Grid2DLike, xp=None) -> aa.Imaging:
         """
         Simulate an `Imaging` dataset from an input `Tracer` object and a 2D grid of (y,x) coordinates.
 
@@ -49,6 +49,9 @@ class SimulatorImaging(aa.SimulatorImaging):
             The 2D grid of (y,x) coordinates which the mass profiles of the galaxies in the tracer are ray-traced using
             in order to generate the image of the galaxies via their light profiles.
         """
+
+        if xp is None:
+            xp = self._xp
 
         tracer.set_snr_of_snr_light_profiles(
             grid=grid,


### PR DESCRIPTION
## Summary

Companion PR to the PyAutoArray PR adding `use_jax=True` to `aa.SimulatorImaging`. Changes the `via_tracer_from` override to default `xp=None` and fall back to `self._xp` (inherited from the parent).

After both PRs merge:
```python
simulator = al.SimulatorImaging(exposure_time=300.0, psf=psf, use_jax=True)
dataset = simulator.via_tracer_from(tracer=tracer, grid=grid)  # JAX-backed
```

## API Changes

- **Changed signature:** `al.SimulatorImaging.via_tracer_from(tracer, grid, xp=None)` — `xp` now defaults to `None`, meaning "fall back to `self._xp`" (inherited from the parent `aa.SimulatorImaging`). Explicit `xp=` still honoured.

See full details below.

## Test Plan

- [x] PyAutoLens 317/317 tests pass.
- [x] Eager cross-xp parity (via the `autolens_workspace_test` parity script bundled with the workspace_test follow-up).

<details>
<summary>Full API Changes</summary>

### Changed signature
- `al.SimulatorImaging.via_tracer_from(tracer, grid, xp=None)` — was `xp=np`. New behaviour: `xp=None` falls back to `self._xp` from the parent (jnp if `use_jax=True`, np otherwise).

### Migration
- No breaking changes. Existing callers passing `xp=np` or no `xp=` continue to work.

### Depends on
- Jammy2211/PyAutoArray PR adding `use_jax` to `aa.SimulatorImaging` (this PR's `self._xp` reference comes from the parent class). Merge PyAutoArray PR first.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)