### PR TITLE
feat: SimulatorInterferometer.via_tracer_from auto-default xp from parent use_jax

### DIFF
--- a/autolens/interferometer/simulator.py
+++ b/autolens/interferometer/simulator.py
@@ -21,7 +21,7 @@ from autolens.lens.tracer import Tracer
 
 
 class SimulatorInterferometer(aa.SimulatorInterferometer):
-    def via_tracer_from(self, tracer, grid):
+    def via_tracer_from(self, tracer, grid, xp=None):
         """
         Returns a realistic simulated image by applying effects to a plain simulated image.
 
@@ -42,11 +42,14 @@ class SimulatorInterferometer(aa.SimulatorInterferometer):
             A seed for random noise_maps generation
         """
 
-        image = tracer.image_2d_from(grid=grid)
+        if xp is None:
+            xp = self._xp
 
-        return self.via_image_from(image=image)
+        image = tracer.image_2d_from(grid=grid, xp=xp)
 
-    def via_galaxies_from(self, galaxies, grid):
+        return self.via_image_from(image=image, xp=xp)
+
+    def via_galaxies_from(self, galaxies, grid, xp=None):
         """Simulate imaging data for this data, as follows:
 
         1)  Setup the image-plane grid of the Imaging arrays, which defines the coordinates used for the ray-tracing.
@@ -64,7 +67,7 @@ class SimulatorInterferometer(aa.SimulatorInterferometer):
 
         tracer = Tracer(galaxies=galaxies)
 
-        return self.via_tracer_from(tracer=tracer, grid=grid)
+        return self.via_tracer_from(tracer=tracer, grid=grid, xp=xp)
 
     def via_deflections_and_galaxies_from(
         self, deflections: aa.VectorYX2D, galaxies: List[ag.Galaxy]


### PR DESCRIPTION
## Summary

Companion PR to the PyAutoArray PR adding `use_jax=True` to `aa.SimulatorInterferometer`. The autolens `via_tracer_from` and `via_galaxies_from` overrides gain `xp=None` parameter and default to `self._xp` from the parent.

After both PRs merge:
```python
simulator = al.SimulatorInterferometer(
    uv_wavelengths=uv_wavelengths, exposure_time=300.0, use_jax=True
)
dataset = simulator.via_tracer_from(tracer=tracer, grid=grid)  # JAX-backed
```

## API Changes

- **Changed signature:** `al.SimulatorInterferometer.via_tracer_from(tracer, grid, xp=None)` and `via_galaxies_from(galaxies, grid, xp=None)` — both gain `xp` parameter; `xp=None` falls back to `self._xp`.

See full details below.

## Test Plan

- [x] PyAutoLens 317/317 tests pass.
- [x] Eager cross-xp parity via the workspace_test parity script.

<details>
<summary>Full API Changes</summary>

### Changed signature
- `al.SimulatorInterferometer.via_tracer_from(tracer, grid, xp=None)`.
- `al.SimulatorInterferometer.via_galaxies_from(galaxies, grid, xp=None)`.

### Migration
- No breaking changes. Existing callers continue to work.

### Depends on
- Jammy2211/PyAutoArray PR adding `use_jax` to `aa.SimulatorInterferometer`. Merge PyAutoArray PR first.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)