### PR TITLE
Add subplot_fit_quick for point source quick updates

### DIFF
--- a/autolens/point/model/plotter.py
+++ b/autolens/point/model/plotter.py
@@ -5,6 +5,7 @@ from autolens.imaging.plot.fit_imaging_plots import _compute_critical_curve_line
 
 from autolens.point.fit.dataset import FitPointDataset
 from autolens.point.plot.fit_point_plots import subplot_fit as subplot_fit_point
+from autolens.point.plot.fit_point_plots import subplot_fit_quick as subplot_fit_quick_point
 from autolens.point.dataset import PointDataset
 from autolens.point.plot.point_dataset_plots import subplot_dataset
 
@@ -78,7 +79,14 @@ class PlotterPoint(Plotter):
                 source_plane_lines, source_plane_line_colors,
             )
 
-        if should_plot("subplot_fit") or quick_update:
+        if quick_update:
+            subplot_fit_quick_point(
+                fit, output_path=output_path, output_format=fmt,
+                title_prefix=self.title_prefix,
+            )
+            return
+
+        if should_plot("subplot_fit"):
             subplot_fit_point(
                 fit, output_path=output_path, output_format=fmt,
                 image_plane_lines=ip_lines,
@@ -87,6 +95,3 @@ class PlotterPoint(Plotter):
                 source_plane_line_colors=sp_colors,
                 title_prefix=self.title_prefix,
             )
-
-        if quick_update:
-            return

--- a/autolens/point/plot/fit_point_plots.py
+++ b/autolens/point/plot/fit_point_plots.py
@@ -84,3 +84,47 @@ def subplot_fit(
 
     tight_layout()
     save_figure(fig, path=output_path, filename="fit", format=output_format)
+
+
+def subplot_fit_quick(
+    fit,
+    output_path: Optional[str] = None,
+    output_format: str = None,
+    title_prefix: str = None,
+):
+    """
+    Produce a single-panel quick-update subplot for a `FitPointDataset`.
+
+    Shows the observed positions with the model-predicted positions
+    overlaid in red. A minimal progress view for quick updates during
+    sampling — will be expanded in future.
+    """
+    from autogalaxy.util.plot_utils import plot_grid
+
+    obs_grid = np.array(
+        fit.dataset.positions.array
+        if hasattr(fit.dataset.positions, "array")
+        else fit.dataset.positions
+    )
+    model_grid = np.array(
+        fit.positions.model_data.array
+        if hasattr(fit.positions.model_data, "array")
+        else fit.positions.model_data
+    )
+
+    _prefix = f"{title_prefix.rstrip()} " if title_prefix else ""
+    fig, ax = subplots(1, 1, figsize=conf_subplot_figsize(1, 1))
+
+    plot_grid(
+        grid=obs_grid,
+        ax=ax,
+        title=f"{_prefix}{fit.dataset.name} Positions",
+        output_path=None,
+        output_filename=None,
+        output_format=output_format,
+    )
+    ax.scatter(model_grid[:, 1], model_grid[:, 0], c="r", s=20, zorder=5, label="Model")
+    ax.legend(fontsize=7, loc="upper right")
+
+    tight_layout()
+    save_figure(fig, path=output_path, filename="fit_quick", format=output_format, dpi=100)


### PR DESCRIPTION
## Summary

Adds a single-panel `subplot_fit_quick` for point source data: observed positions with model-predicted positions overlaid in red. Uses `plot_grid` from the standard pipeline for consistent styling.

Quick updates now call `subplot_fit_quick` instead of the full `subplot_fit`.

## API Changes

New function `autolens.point.plot.fit_point_plots.subplot_fit_quick`.

## Test Plan

- [x] Profiling: fit ~0s, render ~2s
- [ ] Manual: check fit_quick.png output

🤖 Generated with [Claude Code](https://claude.com/claude-code)