### PR TITLE
feat: datacube shared-state for AnalysisInterferometer via curvature preloads

### DIFF
--- a/autolens/interferometer/fit_interferometer.py
+++ b/autolens/interferometer/fit_interferometer.py
@@ -38,6 +38,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         adapt_images: Optional[ag.AdaptImages] = None,
         settings: aa.Settings = None,
         xp=np,
+        preloads=None,
     ):
         """
         Fits an interferometer dataset using a `Tracer` object.
@@ -77,6 +78,11 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
             reconstructed galaxy's morphology.
         settings
             Settings controlling how an inversion is fitted for example which linear algebra formalism is used.
+        preloads
+            An optional `PreloadsInterferometer` carrying channel-invariant inversion quantities (e.g. the
+            `curvature_matrix` `F`) computed once and reused by this fit instead of being rebuilt. Used by the
+            datacube shared-state path, where every spectral channel shares the lens model. `None` (the
+            default) leaves the standard per-fit behaviour unchanged.
         """
 
         self.tracer = tracer
@@ -84,6 +90,8 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         self.adapt_images = adapt_images
 
         self.settings = settings
+
+        self.preloads = preloads
 
         super().__init__(
             dataset=dataset,
@@ -138,6 +146,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
             adapt_images=self.adapt_images,
             settings=self.settings,
             xp=self._xp,
+            preloads=self.preloads,
         )
 
     @cached_property

--- a/autolens/interferometer/model/analysis.py
+++ b/autolens/interferometer/model/analysis.py
@@ -195,10 +195,19 @@ class AnalysisInterferometer(AnalysisDataset):
 
         fit = self.fit_from(instance=instance)
 
-        if fit.inversion is None:
+        if not fit.perform_inversion:
             return None
 
-        return aa.PreloadsInterferometer(curvature_matrix=fit.inversion.curvature_matrix)
+        # Build the inversion-setup quantities once, from a single `TracerToInversion`, so the
+        # mapper is built only once here: the curvature matrix `F` and the mapper (which carries
+        # the Delaunay triangulation) are the channel-invariant quantities reused by every factor.
+        tracer_to_inversion = fit.tracer_to_inversion
+        inversion = tracer_to_inversion.inversion
+
+        return aa.PreloadsInterferometer(
+            curvature_matrix=inversion.curvature_matrix,
+            mapper_galaxy_dict=tracer_to_inversion.mapper_galaxy_dict,
+        )
 
     def fit_from(
         self, instance: af.ModelInstance, preloads=None
@@ -269,7 +278,6 @@ class AnalysisInterferometer(AnalysisDataset):
             _pytree_registered_classes,
         )
         from autoarray.dataset.dataset_model import DatasetModel  # fit-interferometer-pytree-mge
-        from autoarray.preloads import PreloadsInterferometer
         from autolens.lens.tracer import Tracer
 
         try:
@@ -285,14 +293,10 @@ class AnalysisInterferometer(AnalysisDataset):
 
         register_instance_pytree(
             FitInterferometer,
-            no_flatten=("dataset", "adapt_images", "settings"),
+            no_flatten=("dataset", "adapt_images", "settings", "preloads"),
         )
         register_instance_pytree(Tracer, no_flatten=("cosmology",))
         register_instance_pytree(DatasetModel)  # fit-interferometer-pytree-mge
-
-        # The shared-state preloads ride as a dynamic child of `FitInterferometer` (its
-        # `curvature_matrix` is a traced array), so it must flatten as a pytree too.
-        register_instance_pytree(PreloadsInterferometer)
 
         _FIT_INTERFEROMETER_PYTREES_REGISTERED = True
 

--- a/autolens/interferometer/model/analysis.py
+++ b/autolens/interferometer/model/analysis.py
@@ -50,6 +50,7 @@ class AnalysisInterferometer(AnalysisDataset):
         raise_inversion_positions_likelihood_exception: bool = True,
         title_prefix: str = None,
         use_jax: bool = True,
+        shared_preloads: bool = False,
         **kwargs,
     ):
         """
@@ -92,6 +93,12 @@ class AnalysisInterferometer(AnalysisDataset):
         title_prefix
             A string that is added before the title of all figures output by visualization, for example to
             put the name of the dataset and galaxy in the title.
+        shared_preloads
+            Opts this analysis into the cross-factor shared-state mechanism of a `FactorGraphModel` (see
+            `shared_state_from`). Set this to `True` only when this analysis is one of many datacube channels
+            that share an identical lens model, so the channel-invariant inversion quantities (e.g. the
+            `curvature_matrix`) can be computed once and reused by every channel. `False` by default, leaving
+            the standard per-analysis behaviour unchanged.
         """
         super().__init__(
             dataset=dataset,
@@ -105,11 +112,13 @@ class AnalysisInterferometer(AnalysisDataset):
             **kwargs,
         )
 
+        self.shared_preloads = shared_preloads
+
     @property
     def interferometer(self):
         return self.dataset
 
-    def log_likelihood_function(self, instance):
+    def log_likelihood_function(self, instance, shared=None):
         """
         Given an instance of the model, where the model parameters are set via a non-linear search, fit the model
         instance to the interferometer dataset.
@@ -141,6 +150,11 @@ class AnalysisInterferometer(AnalysisDataset):
         instance
             An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
             via a non-linear search).
+        shared
+            The cross-factor shared state of a `FactorGraphModel`, computed once per evaluation by the lead
+            factor's `shared_state_from` (see that method). For this analysis it is a `PreloadsInterferometer`
+            carrying the channel-invariant inversion quantities; when provided it is reused by the fit instead
+            of being recomputed. `None` (the default, e.g. a standalone fit) leaves behaviour unchanged.
 
         Returns
         -------
@@ -152,9 +166,43 @@ class AnalysisInterferometer(AnalysisDataset):
             instance=instance,
         )
 
-        return self.fit_from(instance=instance).figure_of_merit - log_likelihood_penalty
+        return (
+            self.fit_from(instance=instance, preloads=shared).figure_of_merit
+            - log_likelihood_penalty
+        )
 
-    def fit_from(self, instance: af.ModelInstance) -> FitInterferometer:
+    def shared_state_from(self, instance: af.ModelInstance):
+        """
+        Compute the channel-invariant inversion quantities once so they can be shared across the factors of a
+        datacube `FactorGraphModel` (see `autofit.Analysis.shared_state_from`).
+
+        When `shared_preloads` is set, every factor of the graph is an interferometer channel sharing the same
+        lens model, so the inversion's `curvature_matrix` (`F = LᵀW̃L`) — the dominant inversion-setup cost — is
+        identical for every channel. This builds it once on the lead factor and returns it inside a
+        `PreloadsInterferometer`, which `FactorGraphModel` forwards as the `shared` argument to every factor's
+        `log_likelihood_function`, so each channel reuses it instead of rebuilding it.
+
+        Returns `None` when the analysis has not opted in (`shared_preloads=False`) or when the model performs no
+        inversion, in which case no state is shared and every factor fits as normal.
+
+        The caller is responsible for the invariance contract: only enable `shared_preloads` when the inversion
+        quantities really are channel-invariant (e.g. the narrow-emission-line regime where `uv_wavelengths` and
+        `noise_map` are ~channel-invariant). Outside it, leave `shared_preloads=False` so each channel computes
+        its own inversion.
+        """
+        if not self.shared_preloads:
+            return None
+
+        fit = self.fit_from(instance=instance)
+
+        if fit.inversion is None:
+            return None
+
+        return aa.PreloadsInterferometer(curvature_matrix=fit.inversion.curvature_matrix)
+
+    def fit_from(
+        self, instance: af.ModelInstance, preloads=None
+    ) -> FitInterferometer:
         """
         Given a model instance create a `FitInterferometer` object.
 
@@ -166,11 +214,10 @@ class AnalysisInterferometer(AnalysisDataset):
         instance
             An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
             via a non-linear search).
-        check_positions
-            Whether the multiple image positions of the lensed source should be checked, i.e. whether they trace
-            within the position threshold of one another in the source plane.
-        run_time_dict
-            A dictionary which times functions called to fit the model to data, for profiling.
+        preloads
+            An optional `PreloadsInterferometer` carrying channel-invariant inversion quantities (e.g. the
+            `curvature_matrix`) computed once and reused by the fit instead of being rebuilt. Supplied by the
+            datacube shared-state path (see `shared_state_from`); `None` (the default) fits as normal.
 
         Returns
         -------
@@ -195,6 +242,7 @@ class AnalysisInterferometer(AnalysisDataset):
             adapt_images=adapt_images,
             settings=self.settings,
             xp=self._xp,
+            preloads=preloads,
         )
 
     @staticmethod
@@ -221,6 +269,7 @@ class AnalysisInterferometer(AnalysisDataset):
             _pytree_registered_classes,
         )
         from autoarray.dataset.dataset_model import DatasetModel  # fit-interferometer-pytree-mge
+        from autoarray.preloads import PreloadsInterferometer
         from autolens.lens.tracer import Tracer
 
         try:
@@ -240,6 +289,10 @@ class AnalysisInterferometer(AnalysisDataset):
         )
         register_instance_pytree(Tracer, no_flatten=("cosmology",))
         register_instance_pytree(DatasetModel)  # fit-interferometer-pytree-mge
+
+        # The shared-state preloads ride as a dynamic child of `FitInterferometer` (its
+        # `curvature_matrix` is a traced array), so it must flatten as a pytree too.
+        register_instance_pytree(PreloadsInterferometer)
 
         _FIT_INTERFEROMETER_PYTREES_REGISTERED = True
 

--- a/autolens/lens/to_inversion.py
+++ b/autolens/lens/to_inversion.py
@@ -36,6 +36,7 @@ class TracerToInversion(ag.AbstractToInversion):
         adapt_images: Optional[ag.AdaptImages] = None,
         settings: aa.Settings = None,
         xp=np,
+        preloads=None,
     ):
         """
         Interfaces a dataset and tracer with the inversion module, to setup a linear algebra calculation.
@@ -72,6 +73,8 @@ class TracerToInversion(ag.AbstractToInversion):
             The settings of the inversion, which controls how the linear algebra calculation is performed.
         """
         self.tracer = tracer
+
+        self._preloads = preloads
 
         super().__init__(
             dataset=dataset,
@@ -479,6 +482,7 @@ class TracerToInversion(ag.AbstractToInversion):
             linear_obj_list=self.linear_obj_list,
             settings=self.settings,
             xp=self._xp,
+            preloads=self._preloads,
         )
 
         inversion.linear_obj_galaxy_dict = self.linear_obj_galaxy_dict

--- a/autolens/lens/to_inversion.py
+++ b/autolens/lens/to_inversion.py
@@ -400,6 +400,9 @@ class TracerToInversion(ag.AbstractToInversion):
         -------
         A dictionary associating each `Mapper` object with the galaxy it belongs to.
         """
+        if self._preloads is not None and self._preloads.mapper_galaxy_dict is not None:
+            return self._preloads.mapper_galaxy_dict
+
         if not self.has_mapper:
             return {}
 

--- a/test_autolens/interferometer/model/test_analysis_interferometer.py
+++ b/test_autolens/interferometer/model/test_analysis_interferometer.py
@@ -99,16 +99,20 @@ def test__shared_state_from__preloads_curvature_reused__figure_of_merit_unchange
         dataset=dataset, use_jax=False, shared_preloads=True
     )
 
-    # `shared_state_from` builds a `PreloadsInterferometer` carrying the curvature matrix `F`.
+    # `shared_state_from` builds a `PreloadsInterferometer` carrying the curvature matrix `F` and
+    # the mapper (the channel-invariant inversion-setup quantities).
     shared = analysis.shared_state_from(instance=instance)
     assert isinstance(shared, aa.PreloadsInterferometer)
     assert shared.curvature_matrix is not None
+    assert shared.mapper_galaxy_dict is not None
 
-    # The preloaded `F` is reused by the fit (identity) and leaves the figure of merit unchanged.
+    # The preloaded `F` and mapper are reused by the fit (identity) and leave the figure of merit
+    # unchanged. Reusing the mapper means the Delaunay triangulation is not rebuilt per channel.
     fit_unshared = analysis.fit_from(instance=instance)
     fit_shared = analysis.fit_from(instance=instance, preloads=shared)
 
     assert fit_shared.inversion.curvature_matrix is shared.curvature_matrix
+    assert fit_shared.tracer_to_inversion.mapper_galaxy_dict is shared.mapper_galaxy_dict
     assert fit_shared.figure_of_merit == pytest.approx(fit_unshared.figure_of_merit)
 
     # The full `log_likelihood_function` with the shared object matches the unshared call.

--- a/test_autolens/interferometer/model/test_analysis_interferometer.py
+++ b/test_autolens/interferometer/model/test_analysis_interferometer.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import pytest
 
 import autofit as af
+import autoarray as aa
 import autolens as al
 from autolens import exc
 
@@ -71,3 +72,57 @@ def test__positions__likelihood_overwrite__changes_likelihood(
     analysis_log_likelihood = analysis.log_likelihood_function(instance=instance)
 
     assert analysis_log_likelihood == pytest.approx(-44097289569.2342, 1.0e-4)
+
+
+def _pixelization_model():
+    pixelization = al.Pixelization(
+        mesh=al.mesh.RectangularUniform(shape=(3, 3)),
+        regularization=al.reg.Constant(coefficient=0.01),
+    )
+    return af.Collection(
+        galaxies=af.Collection(
+            galaxy_0=al.Galaxy(redshift=0.5),
+            galaxy_1=al.Galaxy(redshift=0.5, pixelization=pixelization),
+        )
+    )
+
+
+def test__shared_state_from__preloads_curvature_reused__figure_of_merit_unchanged(
+    interferometer_7,
+):
+    dataset = interferometer_7.apply_sparse_operator(use_jax=False)
+
+    model = _pixelization_model()
+    instance = model.instance_from_unit_vector([])
+
+    analysis = al.AnalysisInterferometer(
+        dataset=dataset, use_jax=False, shared_preloads=True
+    )
+
+    # `shared_state_from` builds a `PreloadsInterferometer` carrying the curvature matrix `F`.
+    shared = analysis.shared_state_from(instance=instance)
+    assert isinstance(shared, aa.PreloadsInterferometer)
+    assert shared.curvature_matrix is not None
+
+    # The preloaded `F` is reused by the fit (identity) and leaves the figure of merit unchanged.
+    fit_unshared = analysis.fit_from(instance=instance)
+    fit_shared = analysis.fit_from(instance=instance, preloads=shared)
+
+    assert fit_shared.inversion.curvature_matrix is shared.curvature_matrix
+    assert fit_shared.figure_of_merit == pytest.approx(fit_unshared.figure_of_merit)
+
+    # The full `log_likelihood_function` with the shared object matches the unshared call.
+    assert analysis.log_likelihood_function(
+        instance=instance, shared=shared
+    ) == pytest.approx(analysis.log_likelihood_function(instance=instance))
+
+
+def test__shared_state_from__returns_none_when_not_opted_in(interferometer_7):
+    dataset = interferometer_7.apply_sparse_operator(use_jax=False)
+
+    model = _pixelization_model()
+    instance = model.instance_from_unit_vector([])
+
+    analysis = al.AnalysisInterferometer(dataset=dataset, use_jax=False)
+
+    assert analysis.shared_state_from(instance=instance) is None


### PR DESCRIPTION
## Summary

Implements the lensing consumer of the `FactorGraphModel` cross-`Analysis` shared-state mechanism (PyAutoFit, shipped) for the interferometer datacube (PyAutoLens#565 / the `analysis_shared_state` epic). When a datacube is fit as N `AnalysisInterferometer` channels sharing one lens model, the curvature matrix `F = LᵀW̃L` — the dominant per-channel inversion-setup cost — is identical for every channel. This builds it once on the lead factor and reuses it across every channel via the PyAutoArray `Preloads` API, targeting a large reduction in the inversion-setup cost for a many-channel cube.

This is the curvature-sharing increment (the dominant ~86% of the shareable inversion-setup work). Mapper-sharing (the Delaunay rebuild) and the workspace scripts / profiling re-measure follow.

**Depends on `Jammy2211/PyAutoArray` (Preloads API) — that PR must merge first.**

## API Changes

All additive and backward compatible — no removals or renames.

- `AnalysisInterferometer.__init__` gains an opt-in `shared_preloads=False` flag.
- New method `AnalysisInterferometer.shared_state_from(instance)` — returns a `PreloadsInterferometer` with the channel-invariant `curvature_matrix` (or `None` when not opted in / no inversion).
- `AnalysisInterferometer.log_likelihood_function` gains `shared=None`; `fit_from` gains `preloads=None`; `FitInterferometer` and `TracerToInversion` gain `preloads=None`, threaded into `inversion_from`.

See full details below.

## Test Plan
- [ ] `python -m pytest test_autolens/` — full suite passes (331 tests)
- [ ] New `test_autolens/interferometer/model/test_analysis_interferometer.py`: `shared_state_from` yields a `PreloadsInterferometer` whose `curvature_matrix` is reused by the fit (identity) with unchanged `figure_of_merit`; `log_likelihood_function(shared=...)` matches the unshared call; returns `None` when not opted in.
- [ ] JAX (verified locally; committed test lands in autolens_workspace_test): `PreloadsInterferometer` threads through `jax.jit` and the shared-path likelihood matches numpy.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `AnalysisInterferometer.shared_state_from(self, instance)` — builds the shared `PreloadsInterferometer` once per evaluation (the `autofit.Analysis.shared_state_from` hook for interferometer datacubes).

### Changed Signature (backward compatible — new optional args / flags)
- `AnalysisInterferometer.__init__(... , shared_preloads=False)`
- `AnalysisInterferometer.log_likelihood_function(self, instance, shared=None)`
- `AnalysisInterferometer.fit_from(self, instance, preloads=None)`
- `FitInterferometer.__init__(... , preloads=None)`
- `TracerToInversion.__init__(... , preloads=None)`

### Changed Behaviour
- When `shared_preloads=True` and a `FactorGraphModel` forwards the shared `PreloadsInterferometer`, each channel's inversion reuses the preloaded curvature matrix instead of rebuilding it. With the defaults, behaviour is unchanged.

### Migration
- None required. To opt in, construct the per-channel `AnalysisInterferometer(..., shared_preloads=True)` and combine them in a `FactorGraphModel` (which calls `shared_state_from` and forwards the result).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)