### PR TITLE
refactor(latent): LatentLens class + declare Analysis.Latent (Phase 2)

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -103,6 +103,8 @@ from .analysis.positions import PositionsLH
 from .imaging.simulator import SimulatorImaging
 from .imaging.fit_imaging import FitImaging
 from .imaging.model.analysis import AnalysisImaging
+from autofit import Latent
+from .analysis.latent import LatentLens
 from .imaging.model.visualizer import VisualizerImaging
 from .interferometer.simulator import SimulatorInterferometer
 from .interferometer.fit_interferometer import FitInterferometer

--- a/autolens/analysis/latent.py
+++ b/autolens/analysis/latent.py
@@ -23,6 +23,7 @@ from typing import Callable, Dict, List, Optional
 
 import numpy as np
 
+import autofit as af
 from autoconf import conf
 from autogalaxy.imaging.model.latent import (
     ab_mag_via_flux_from,
@@ -298,3 +299,38 @@ def latent_keys_enabled(yaml_config: Optional[Dict[str, bool]] = None) -> List[s
             continue
         enabled.append(key)
     return enabled
+
+
+class LatentLens(af.Latent):
+    """
+    Latent-variable catalogue for strong-lens fits, declared on
+    ``AnalysisImaging`` as ``Latent = LatentLens`` (mirrors ``Visualizer`` /
+    ``Result``).
+
+    :meth:`keys` returns the config-enabled latent names; :meth:`variables`
+    dispatches the :data:`LATENT_FUNCTIONS` registry on a per-sample fit.
+    Subclass to add project-specific latents (e.g. the Euclid pipeline's
+    aperture fluxes), composing the library values via
+    ``LatentLens.variables(analysis, parameters, model)``.
+    """
+
+    # The lensing Einstein-radius latent routes through ``ZeroSolver``
+    # (uses ``lax.cond`` / ``lax.while_loop``, vmap-incompatible), so latents
+    # use the per-sample jit batch path.
+    BATCH_MODE = "jit"
+
+    @staticmethod
+    def keys(analysis) -> List[str]:
+        return latent_keys_enabled()
+
+    @staticmethod
+    def variables(analysis, parameters, model):
+        keys = latent_keys_enabled()
+        if not keys:
+            raise NotImplementedError
+        xp = analysis._xp
+        instance = model.instance_from_vector(vector=parameters)
+        fit = analysis.fit_from(instance=instance)
+        magzero = analysis.kwargs.get("magzero", None)
+        context = {"fit": fit, "magzero": magzero, "xp": xp}
+        return tuple(LATENT_FUNCTIONS[k](**context) for k in keys)

--- a/autolens/imaging/model/analysis.py
+++ b/autolens/imaging/model/analysis.py
@@ -18,6 +18,7 @@ import autofit as af
 import autogalaxy as ag
 
 from autolens.analysis.analysis.dataset import AnalysisDataset
+from autolens.analysis.latent import LatentLens
 from autolens.imaging.model.result import ResultImaging
 from autolens.imaging.model.visualizer import VisualizerImaging
 from autolens.imaging.fit_imaging import FitImaging
@@ -34,38 +35,7 @@ class AnalysisImaging(AnalysisDataset):
 
     Result = ResultImaging
     Visualizer = VisualizerImaging
-
-    @property
-    def LATENT_KEYS(self):
-        from autolens.analysis.latent import latent_keys_enabled
-        return latent_keys_enabled()
-
-    def compute_latent_variables(self, parameters, model):
-        """
-        Compute the catalogue of lensing latent variables enabled in
-        ``config/latent.yaml`` for the given parameter vector.
-
-        Returns a tuple positionally aligned with :attr:`LATENT_KEYS` —
-        PyAutoFit zips it with the keys at
-        ``autofit/non_linear/analysis/analysis.py:285`` and stacks per
-        sample for the JIT batch path at lines 223-234.
-
-        Raises ``NotImplementedError`` when no latents are enabled so
-        PyAutoFit's outer ``except NotImplementedError`` short-circuits
-        the latent pipeline cleanly (no empty ``latent.csv`` written).
-        """
-        from autolens.analysis.latent import LATENT_FUNCTIONS
-
-        keys = self.LATENT_KEYS
-        if not keys:
-            raise NotImplementedError
-
-        xp = self._xp
-        instance = model.instance_from_vector(vector=parameters)
-        fit = self.fit_from(instance=instance)
-        magzero = self.kwargs.get("magzero", None)
-        context = {"fit": fit, "magzero": magzero, "xp": xp}
-        return tuple(LATENT_FUNCTIONS[k](**context) for k in keys)
+    Latent = LatentLens
 
     def log_likelihood_function(self, instance: af.ModelInstance) -> float:
         """

--- a/test_autolens/analysis/test_latent.py
+++ b/test_autolens/analysis/test_latent.py
@@ -11,6 +11,7 @@ import autolens as al
 from autolens.analysis import latent as _latent_module
 from autolens.analysis.latent import (
     LATENT_FUNCTIONS,
+    LatentLens,
     effective_einstein_radius,
     latent_keys_enabled,
     magnification,
@@ -410,7 +411,7 @@ def test_latent_functions_registry_keys():
 # AnalysisImaging end-to-end
 # ---------------------------------------------------------------------------
 
-def test_analysis_imaging_compute_latent_variables_aligns_with_keys(
+def test_latent_lens_variables_aligns_with_keys(
     masked_imaging_7x7,
 ):
     lens_galaxy = al.Galaxy(redshift=0.5, light=al.lp.Sersic(intensity=0.1))
@@ -424,13 +425,14 @@ def test_analysis_imaging_compute_latent_variables_aligns_with_keys(
     )
 
     parameters = np.array(model.physical_values_from_prior_medians)
-    values = analysis.compute_latent_variables(parameters=parameters, model=model)
+    values = LatentLens.variables(analysis, parameters=parameters, model=model)
+    keys = LatentLens.keys(analysis)
 
     assert isinstance(values, tuple)
-    assert len(values) == len(analysis.LATENT_KEYS)
+    assert len(values) == len(keys)
     # test_autolens/config/latent.yaml enables the three raw-flux keys plus
     # total_lens_flux_mujy. magzero=25.0 above keeps the µJy column finite.
-    assert analysis.LATENT_KEYS == [
+    assert keys == [
         "total_lens_flux",
         "total_lensed_source_flux",
         "total_source_flux",
@@ -439,24 +441,21 @@ def test_analysis_imaging_compute_latent_variables_aligns_with_keys(
     assert all(np.isfinite(v) for v in values)
 
 
-def test_analysis_imaging_compute_latent_variables_raises_when_empty(monkeypatch):
-    monkeypatch.setattr(
-        al.AnalysisImaging,
-        "LATENT_KEYS",
-        property(lambda self: []),
-    )
+def test_latent_lens_variables_raises_when_empty(monkeypatch):
+    monkeypatch.setattr(_latent_module, "latent_keys_enabled", lambda *a, **k: [])
     analysis = al.AnalysisImaging(dataset=MagicMock(), use_jax=False)
 
     with pytest.raises(NotImplementedError):
-        analysis.compute_latent_variables(parameters=np.array([]), model=MagicMock())
+        LatentLens.variables(analysis, parameters=np.array([]), model=MagicMock())
 
 
-def test_analysis_imaging_latent_keys_property_reads_config():
+def test_analysis_imaging_declares_latent_lens_and_keys_read_config():
     # The autouse `set_config_path` fixture in test_autolens/conftest.py
     # pushes test_autolens/config/latent.yaml — the three raw-flux keys
     # and total_lens_flux_mujy are enabled there.
     analysis = al.AnalysisImaging(dataset=MagicMock(), use_jax=False)
-    assert analysis.LATENT_KEYS == [
+    assert al.AnalysisImaging.Latent is LatentLens
+    assert LatentLens.keys(analysis) == [
         "total_lens_flux",
         "total_lensed_source_flux",
         "total_source_flux",


### PR DESCRIPTION
## Summary
**Phase 2 of the latent redesign** (first-class `Latent` class). Depends on PyAutoFit #1315 (Phase 1, af.Latent) — do NOT merge into a release; CI fails until #1315 lands. See PyAutoPrompt/autofit/latent_class_redesign.md.

`LatentLens(af.Latent)` (static keys/variables, BATCH_MODE=jit) owns the registry dispatch; `AnalysisImaging.Latent = LatentLens`; legacy `LATENT_KEYS`/`compute_latent_variables` removed. Exports `al.Latent` + `al.LatentLens`. Tests migrated.

## Test Plan
- [x] test_autolens/analysis (52 passed) incl. test_latent (24)
- [x] latent_variables_smoke (8 latents) + latent_nan_robustness guards — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)