### PR TITLE
docs: add dPIEMassLenstool / dPIEMassLenstoolSph to mass API autosummary

### DIFF
--- a/docs/api/mass.rst
+++ b/docs/api/mass.rst
@@ -24,6 +24,8 @@ Total [ag.mp]
    IsothermalSph
    dPIEMass
    dPIEMassSph
+   dPIEMassLenstool
+   dPIEMassLenstoolSph
    PIEMass
    dPIEPotential
    dPIEPotentialSph


### PR DESCRIPTION
## Summary

Docs-only mirror of PyAutoLabs/PyAutoGalaxy#487: adds the new Lenstool-parameterized dPIE profiles (`dPIEMassLenstool`, `dPIEMassLenstoolSph`) to the mass-profile API autosummary. PyAutoLens re-exports `autogalaxy.profiles.mass`, so the symbols are available as `al.mp.*` with no source change.

## API Changes

None — internal changes only (documentation autosummary entries; the symbols themselves land via the PyAutoGalaxy PR).

## Test Plan
- [x] No runtime change; docs build covered by CI.

## Validation checklist (--auto run — in-session directives, no separate plan pre-approval)
- Effective level: supervised (header: supervised, cap: feature → supervised); companion docs mirror of the user-directed wrapper-class work
- Plan: on the issue (PyAutoLabs/PyAutoGalaxy#485)
- Gate: docs-only; downstream PyAutoLens suite run against the PyAutoGalaxy branch (result in issue) · Heart YELLOW acked in-session
- [ ] Human: merge with (after) the PyAutoGalaxy PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
