### PR TITLE
feat: cap SimulatorShearYX catalogue size under PYAUTO_SMALL_DATASETS (weak series step 9)

### DIFF
--- a/autolens/weak/simulator.py
+++ b/autolens/weak/simulator.py
@@ -113,6 +113,12 @@ class SimulatorShearYX:
         name
             Optional label passed through to ``WeakDataset.name``.
         """
+        from autoarray.util import dataset_util
+
+        # Smoke-mode cap (PYAUTO_SMALL_DATASETS=1): generated catalogue sizes only —
+        # via_tracer_from's user-provided grid is never mutated.
+        n_galaxies = dataset_util.cap_catalogue_size_for_small_datasets(n_galaxies)
+
         positions = self._rng.uniform(
             low=-grid_extent, high=grid_extent, size=(n_galaxies, 2)
         )

--- a/test_autolens/weak/test_simulator_small_datasets.py
+++ b/test_autolens/weak/test_simulator_small_datasets.py
@@ -1,0 +1,43 @@
+import autolens as al
+
+
+def _tracer():
+    lens = al.Galaxy(
+        redshift=0.5,
+        mass=al.mp.IsothermalSph(centre=(0.0, 0.0), einstein_radius=1.6),
+    )
+    return al.Tracer(galaxies=[lens, al.Galaxy(redshift=1.0)])
+
+
+def test__random_positions__capped_under_small_datasets(monkeypatch):
+    monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
+
+    dataset = al.SimulatorShearYX(noise_sigma=0.3, seed=1).via_tracer_random_positions_from(
+        tracer=_tracer(), n_galaxies=200, grid_extent=3.0
+    )
+
+    assert dataset.n_galaxies == 25
+
+
+def test__random_positions__uncapped_without_env_var(monkeypatch):
+    monkeypatch.delenv("PYAUTO_SMALL_DATASETS", raising=False)
+
+    dataset = al.SimulatorShearYX(noise_sigma=0.3, seed=1).via_tracer_random_positions_from(
+        tracer=_tracer(), n_galaxies=40, grid_extent=3.0
+    )
+
+    assert dataset.n_galaxies == 40
+
+
+def test__explicit_grid__never_capped(monkeypatch):
+    import autoarray as aa
+    import numpy as np
+
+    monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
+
+    grid = aa.Grid2DIrregular(values=np.random.default_rng(1).uniform(-3, 3, (60, 2)))
+    dataset = al.SimulatorShearYX(noise_sigma=0.3, seed=1).via_tracer_from(
+        tracer=_tracer(), grid=grid
+    )
+
+    assert dataset.n_galaxies == 60


### PR DESCRIPTION
## Summary
`via_tracer_random_positions_from` routes `n_galaxies` through autoarray's new `cap_catalogue_size_for_small_datasets` (200 → 25 in smoke mode); the explicit user grid of `via_tracer_from` is deliberately never mutated (tested). With `should_simulate` already adopted (#581), `scripts/weak/modeling.py` under `PYAUTO_SMALL_DATASETS=1 PYAUTO_TEST_MODE=1` regenerates a 25-galaxy catalogue and completes in ~30 s (vs ~7 min). Closes PyAutoLabs/PyAutoLens#583 after merge. **Depends on the companion PyAutoArray PR — merge that first.**

## API Changes
None — internal behaviour of the simulator under a smoke-mode env var; public signatures unchanged.

## Validation checklist (--auto run)
- Effective level: supervised · plan on #583 · tests 356-pass (+3 new) · smoke: modeling.py 30s end-to-end at 25 galaxies · review human sign-off on #583 · Heart YELLOW (acknowledged set)
- [x] Human: ship approved on #583
- [ ] Human: merge after the PyAutoArray PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)