### PR TITLE
fix: mixed-dataset factor graphs crash combined visualization

### DIFF
--- a/autolens/imaging/model/visualizer.py
+++ b/autolens/imaging/model/visualizer.py
@@ -231,13 +231,28 @@ class VisualizerImaging(af.Visualizer):
         if analyses is None:
             return
 
+        # A mixed-dataset factor graph (e.g. imaging + weak lensing) routes every
+        # factor's analysis here; this combined subplot can only draw its own
+        # dataset type, so other analyses are skipped (each still visualizes its
+        # own fit individually).
+        from autolens.imaging.model.analysis import AnalysisImaging
+
+        pairs = [
+            (analysis, single_instance)
+            for analysis, single_instance in zip(analyses, instance)
+            if isinstance(analysis, AnalysisImaging)
+        ]
+
+        if len(pairs) == 0:
+            return
+
         plotter = PlotterImaging(
-            image_path=paths.image_path, title_prefix=analyses[0].title_prefix
+            image_path=paths.image_path, title_prefix=pairs[0][0].title_prefix
         )
 
         fit_list = [
             analysis.fit_for_visualization(instance=single_instance)
-            for analysis, single_instance in zip(analyses, instance)
+            for analysis, single_instance in pairs
         ]
 
         plotter.fit_imaging_combined(

--- a/autolens/interferometer/model/visualizer.py
+++ b/autolens/interferometer/model/visualizer.py
@@ -201,13 +201,28 @@ class VisualizerInterferometer(af.Visualizer):
         if analyses is None:
             return
 
+        # A mixed-dataset factor graph (e.g. imaging + weak lensing) routes every
+        # factor's analysis here; this combined subplot can only draw its own
+        # dataset type, so other analyses are skipped (each still visualizes its
+        # own fit individually).
+        from autolens.interferometer.model.analysis import AnalysisInterferometer
+
+        pairs = [
+            (analysis, single_instance)
+            for analysis, single_instance in zip(analyses, instance)
+            if isinstance(analysis, AnalysisInterferometer)
+        ]
+
+        if len(pairs) == 0:
+            return
+
         plotter = PlotterInterferometer(
-            image_path=paths.image_path, title_prefix=analyses[0].title_prefix
+            image_path=paths.image_path, title_prefix=pairs[0][0].title_prefix
         )
 
         fit_list = [
             analysis.fit_for_visualization(instance=single_instance)
-            for analysis, single_instance in zip(analyses, instance)
+            for analysis, single_instance in pairs
         ]
 
         plotter.fit_interferometer_combined(

--- a/test_autolens/imaging/model/test_visualizer_mixed_graph.py
+++ b/test_autolens/imaging/model/test_visualizer_mixed_graph.py
@@ -1,0 +1,41 @@
+import autoarray as aa
+import autolens as al
+
+from autolens.imaging.model.visualizer import VisualizerImaging
+
+
+class _RaisingPaths:
+    """visualize_combined must return before touching paths when no imaging analysis is present."""
+
+    @property
+    def image_path(self):
+        raise AssertionError("plotting was attempted for a graph with no imaging analyses")
+
+
+def test__visualize_combined__skips_non_imaging_analyses():
+    """
+    A mixed-dataset factor graph (e.g. imaging + weak) routes every factor's analysis into the
+    lead factor's Visualizer.visualize_combined; non-imaging analyses must be filtered out
+    rather than treated as FitImaging producers (which raised AttributeError before the fix).
+    """
+    grid = aa.Grid2DIrregular(values=[(1.0, 1.0), (-1.0, 1.0)])
+    tracer = al.Tracer(
+        galaxies=[
+            al.Galaxy(
+                redshift=0.5,
+                mass=al.mp.IsothermalSph(einstein_radius=1.0),
+            ),
+            al.Galaxy(redshift=1.0),
+        ]
+    )
+    dataset = al.SimulatorShearYX(noise_sigma=0.1, seed=1).via_tracer_from(
+        tracer=tracer, grid=grid
+    )
+    analysis_weak = al.AnalysisWeak(dataset=dataset)
+
+    VisualizerImaging.visualize_combined(
+        analyses=[analysis_weak],
+        paths=_RaisingPaths(),
+        instance=[None],
+        during_analysis=True,
+    )


### PR DESCRIPTION
## Summary
The first mixed-dataset `FactorGraphModel` (AnalysisImaging + AnalysisWeak, built by the weak series' combined strong+weak example) crashed during on-the-fly visualization: PyAutoFit routes **every** factor's analysis into the lead factor's `Visualizer.visualize_combined`, and the imaging/interferometer implementations assumed all analyses were their own type (`AttributeError: 'FitWeak' object has no attribute 'data'`). Both now filter to their own `Analysis` type before building fits and return early (before plotter construction) when none remain; every factor still visualizes its own fit individually. Surfaced by autolens_workspace#247.

## API Changes
None — internal fix to visualization behaviour under mixed factor graphs.

## Test Plan
- [x] New regression test: `VisualizerImaging.visualize_combined` with only non-imaging analyses returns without touching paths.
- [x] Full `test_autolens/` suite: 357 passed.
- [x] End-to-end: the combined strong+weak `modeling.py` joint Nautilus fit runs to completion (previously crashed at the first combined-visualization call).

## Validation checklist (--auto run)
- Effective level: supervised · scope extension recorded on autolens_workspace#247 · review human sign-off on #247 · Heart YELLOW (acknowledged set)
- [x] Human: ship approved on autolens_workspace#247
- [ ] Human: merge before the companion workspace PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)