### PR TITLE
docs: fix dead HowToLens Colab links + purge stale allowlist entries

### DIFF
--- a/.url_check_allowlist.txt
+++ b/.url_check_allowlist.txt
@@ -17,11 +17,6 @@ https://academic.oup.com/mnras/article/488/1/1387/5526256  # CITATIONS.md:22
 # Code of Conduct boilerplate
 http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy  # CODE_OF_CONDUCT.md:305
 
-# Colab refs to notebooks no longer in HowTo/workspace
-https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.5.14.2/notebooks/chapter_3_search_chaining/tutorial_4_complex_source.ipynb  # docs/howtolens/chapter_3_search_chaining.md:20
-https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.5.14.2/notebooks/chapter_4_pixelizations/tutorial_11_adapt_regularization.py.ipynb  # docs/howtolens/chapter_4_pixelizations.md:37
-https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.5.14.2/notebooks/chapter_optional/tutorial_sub_grids.ipynb  # docs/howtolens/chapter_optional.md:7
-
 # External dead / paywalled / departmental pages
 http://www.ita.uni-heidelberg.de/~massimo/sub/Lectures/gl_all.pdf  # docs/howtolens/howtolens.md:36
 https://bitbucket.org/bdiemer/colossus/src/main/  # files/citations.md:12

--- a/docs/howtolens/chapter_3_search_chaining.md
+++ b/docs/howtolens/chapter_3_search_chaining.md
@@ -17,7 +17,7 @@ The chapter contains the following tutorials:
 [Tutorial 4: Two Lens galaxies](https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.7.6.649/notebooks/chapter_3_search_chaining/tutorial_4_x2_lens_galaxies.ipynb)
 \- Modeling a strong lens with two lens galaxies using chained searches.
 
-[Tutorial 5: Complex Source](https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.7.6.649/notebooks/chapter_3_search_chaining/tutorial_4_complex_source.ipynb)
+[Tutorial 5: Complex Source](https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.7.6.649/notebooks/chapter_3_search_chaining/tutorial_5_complex_source.ipynb)
 \- Using multiple light profiles to fit a complex and irregular source using chained searches.
 
 [Tutorial 6: SLaM](https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.7.6.649/notebooks/chapter_3_search_chaining/tutorial_6_slam.ipynb)

--- a/docs/howtolens/chapter_4_pixelizations.md
+++ b/docs/howtolens/chapter_4_pixelizations.md
@@ -34,5 +34,5 @@ The chapter contains the following tutorials:
 [Tutorial 10: Brightness Adaption](https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.7.6.649/notebooks/chapter_4_pixelizations/tutorial_10_brightness_adaption.ipynb)
 \- Adapting the pixelization to the source's morphology.
 
-[Tutorial 11: Adaptive Regularization](https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.7.6.649/notebooks/chapter_4_pixelizations/tutorial_11_adapt_regularization.py.ipynb)
+[Tutorial 11: Adaptive Regularization](https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.7.6.649/notebooks/chapter_4_pixelizations/tutorial_11_adaptive_regularization.ipynb)
 \- Adapting the regularization to the source's morphology.

--- a/docs/howtolens/chapter_optional.md
+++ b/docs/howtolens/chapter_optional.md
@@ -4,8 +4,5 @@ This chapter contains optional tutorials expanding on different aspects of how *
 
 The chapter contains the following tutorials:
 
-[Tutorial: Sub-grids](https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.7.6.649/notebooks/chapter_optional/tutorial_sub_grids.ipynb)
-\- Use sub-grids to perform more accuratee and precise lensing calculations.
-
 [Tutorial: Searches](https://colab.research.google.com/github/PyAutoLabs/HowToLens/blob/2026.7.6.649/notebooks/chapter_optional/tutorial_searches.ipynb)
 \- Alternative non-linear searches to sample parameter space.


### PR DESCRIPTION
## Summary

Final leg of the Colab maturity work (tracker PyAutoLabs/PyAutoBuild#124). Fixes the three dead HowToLens Colab links in `docs/howtolens/` — `tutorial_5_complex_source` (was pointing at a `tutorial_4_` name that doesn't exist), `tutorial_11_adaptive_regularization.ipynb` (was carrying a `.py.ipynb` double extension), and removal of the entry for the deleted `chapter_optional/tutorial_sub_grids` (the chapter now contains only `tutorial_searches`) — and purges the three grandfathered Colab entries from `.url_check_allowlist.txt`.

Every Colab URL in the repo is machine-verified (canonical owner, current tag, target notebook exists in HowToLens) and Heart's hardened offline guard exits clean. Human-directed run: the repo claim held by `release-docs-polish-learn-paths` was explicitly overridden by the maintainer; file-level overlap with that task's uncommitted work (README.md, docs/index.md, docs/overview/overview_2) is zero.

## API Changes
None — docs-only.

## Test Plan
- [x] Colab-URL audit: 0 problems in PyAutoLens after fix
- [x] `heart/checks/url_check.sh` (incl. new phase-1 patterns): CLEAN
- [x] Post-merge central URL sweep dispatch to confirm the Colab rot class is gone ecosystem-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)
