### PR TITLE
docs: document the functional plot API in plot.rst

### DIFF
--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -97,3 +97,52 @@ Module-level functions for visualizing non-linear search results.
    corner_anesthetic
    subplot_parameters
    log_likelihood_vs_iteration
+
+Plot Customization [aplt]
+-------------------------
+
+The plotting API is **functional**: customization is done by passing keyword
+arguments directly to any ``aplt`` plotting function. There is no ``MatPlot2D``
+object anymore (nor the old ``Cmap`` / ``Visuals`` / ``Units`` / matplotlib-wrapper
+classes) — these were removed in favour of the keyword-argument interface below.
+
+Every figure and subplot function accepts:
+
+- ``title`` — the figure title.
+- ``colormap`` — the matplotlib colormap name (e.g. ``"jet"``, ``"hot"``, ``"gray"``).
+- ``use_log10`` — if ``True``, plot the colormap on a ``log10`` scale.
+- ``output_path`` — directory to save the figure to (omit to display it interactively).
+- ``output_filename`` — the saved file's name.
+- ``output_format`` — the saved file's format, e.g. ``"png"`` or ``"pdf"``.
+
+For example:
+
+.. code-block:: python
+
+    import autolens.plot as aplt
+
+    # Customize the appearance:
+    aplt.plot_array(array=image, title="Image", colormap="jet", use_log10=True)
+
+    # Save to disk instead of displaying:
+    aplt.plot_array(
+        array=image, output_path="output", output_filename="image", output_format="png"
+    )
+
+Default plotting values (figure size, fonts, colormaps, ticks, labels, ...) are set
+via the workspace ``config/visualize`` YAML files rather than in code, so most figures
+need no customization at all.
+
+Figure Output [aplt]
+--------------------
+
+The ``Output`` object gives lower-level control of how and where figures are written
+to disk, and is accepted by the plotting functions in place of the individual
+``output_*`` keyword arguments.
+
+.. currentmodule:: autoarray.plot
+
+.. autosummary::
+   :toctree: _autosummary
+
+   Output


### PR DESCRIPTION
## Summary

Documents the **functional plot API** in `docs/api/plot.rst` — the positive follow-up to PyAutoLabs/PyAutoLens#592, which pruned the removed OO plotting subsystem and left the reference thin.

Adds two sections:
- **Plot Customization** — customization is by keyword arguments passed directly to any `aplt.*` function (`title`, `colormap`, `use_log10`, `output_path`, `output_filename`, `output_format`); there is no `MatPlot2D`/`Cmap` object anymore. Defaults come from the workspace `config/visualize` YAML.
- **Figure Output** — the surviving `autoarray.plot.Output` object.

Grounded against the installed API (`dir(autolens.plot)`, `dir(autoarray.plot)`) and `autolens_workspace/scripts/guides/plot/start_here.py`.

## Validation checklist (--auto, supervised)

- **Tests:** n/a — zero Python source changed (single `docs/api/plot.rst`).
- **Smoke:** n/a — no downstream script surface.
- **Review:** CLEAN — re-audit confirms every autosummary entry (the new `Output`) resolves; `docutils` parses the file; CRLF preserved.
- **Heart:** YELLOW — reason set ⊆ the chronic set the maintainer acknowledged at the #592 ship (workspace-validation stale-fail, 58 parked scripts, assistant pin-behind, 10d Mind PR); none from this change, none RED.

Autonomous run ended at **PR-open** (maintainer pre-authorized "both --auto to PR-open"); merge stays human. PyAutoFit's `plot.rst` deferred behind ep-graphical-docs #1334. Issue PyAutoLabs/PyAutoLens#595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
