### PR TITLE
fix: COOLEST interop rejects relative file paths

### DIFF
--- a/autolens/interop/coolest.py
+++ b/autolens/interop/coolest.py
@@ -71,6 +71,8 @@ def _coolest_modules():
 
 
 def _path_no_ext(file_path: str) -> str:
+    # The coolest JSONSerializer rejects relative paths.
+    file_path = os.path.abspath(file_path)
     if file_path.endswith(".json"):
         return file_path[: -len(".json")]
     return file_path
@@ -245,7 +247,7 @@ def to_coolest(
     )
 
     path_no_ext = _path_no_ext(file_path)
-    os.makedirs(os.path.dirname(os.path.abspath(path_no_ext)), exist_ok=True)
+    os.makedirs(os.path.dirname(path_no_ext), exist_ok=True)
     JSONSerializer(path_no_ext, obj=root, check_external_files=False).dump_simple()
 
     return f"{path_no_ext}.json"

--- a/test_autolens/interop/test_coolest.py
+++ b/test_autolens/interop/test_coolest.py
@@ -146,6 +146,22 @@ def test__round_trip__nfw_uses_sigma_crit_from_cosmology(tmp_path):
     assert nfw_default.kappa_s == pytest.approx(0.15, rel=1e-3)
 
 
+def test__round_trip__relative_file_path(tmp_path, monkeypatch):
+    # The coolest JSONSerializer rejects relative paths — to_coolest /
+    # from_coolest must absolutize them.
+    monkeypatch.chdir(tmp_path)
+
+    file_path = interop_coolest.to_coolest(
+        galaxies=lens_model_galaxies(), file_path="template"
+    )
+
+    assert file_path == str(tmp_path / "template.json")
+
+    tracer_back = interop_coolest.from_coolest(file_path="template.json")
+
+    assert len(tracer_back.galaxies) == 3
+
+
 def test__from_coolest__missing_point_estimate_raises(tmp_path):
     pytest.importorskip("coolest")
     from coolest.template.lazy import (


### PR DESCRIPTION
## Summary
Follow-up fix to #613 (issue #612): the `coolest` package's `JSONSerializer` raises `ValueError: Path to JSON file must be an absolute path` when `to_coolest` / `from_coolest` receive a relative `file_path`. Both now absolutize the path (the existing tests all used absolute `tmp_path`, which masked this). Found running the new workspace guide from a relative working directory.

## API Changes
None — behaviour fix only (relative paths now work instead of raising).

## Test Plan
- [x] New regression test `test__round_trip__relative_file_path` (chdir + relative path, both directions).
- [x] `test_autolens/interop/` — 5 passed.

Generated by the PyAutoLabs agent workflow.