### PR TITLE
feat: from_coolest(intermediate=True) — rebuild PEMDs as PowerLawIntermediate

### DIFF
--- a/autolens/interop/coolest.py
+++ b/autolens/interop/coolest.py
@@ -271,6 +271,7 @@ def _parameters_from(coolest_profile) -> Dict:
 def from_coolest(
     file_path: str,
     cosmology: Optional[ag.cosmo.LensingCosmology] = None,
+    intermediate: bool = False,
 ) -> Tracer:
     """
     Build a ``Tracer`` from the analytic profiles of a COOLEST JSON template
@@ -290,6 +291,11 @@ def from_coolest(
         The cosmology of the returned ``Tracer``. Defaults to a
         ``FlatLambdaCDM`` built from the template's H0 / Om0 (or
         ``ag.cosmo.Planck15`` if the template has none).
+    intermediate
+        If True, PEMD profiles are built as ``ag.mp.PowerLawIntermediate``
+        (whose ``einstein_radius`` is the template's ``theta_E`` unchanged)
+        instead of the default ``ag.mp.PowerLaw``. Both give the identical
+        mass distribution.
     """
     _, _, _, JSONSerializer = _coolest_modules()
 
@@ -340,6 +346,7 @@ def from_coolest(
                 profile_type=coolest_profile.type,
                 parameters=_parameters_from(coolest_profile),
                 sigma_crit=sigma_crit,
+                intermediate=intermediate,
             )
 
         galaxies.append(

--- a/test_autolens/interop/test_coolest.py
+++ b/test_autolens/interop/test_coolest.py
@@ -146,6 +146,42 @@ def test__round_trip__nfw_uses_sigma_crit_from_cosmology(tmp_path):
     assert nfw_default.kappa_s == pytest.approx(0.15, rel=1e-3)
 
 
+def test__from_coolest__intermediate_returns_power_law_intermediate(tmp_path):
+    import autogalaxy as ag
+
+    galaxies = [
+        al.Galaxy(
+            redshift=0.5,
+            mass=al.mp.PowerLawIntermediate(
+                centre=(0.0, 0.0),
+                ell_comps=al.convert.ell_comps_from(axis_ratio=0.7, angle=45.0),
+                einstein_radius=1.2,
+                slope=2.1,
+            ),
+        ),
+        al.Galaxy(redshift=1.0, bulge=al.lp.SersicSph(intensity=0.5)),
+    ]
+
+    file_path = interop_coolest.to_coolest(
+        galaxies=galaxies, file_path=str(tmp_path / "template")
+    )
+
+    tracer_back = interop_coolest.from_coolest(
+        file_path=file_path, intermediate=True
+    )
+
+    mass_back = [g for g in tracer_back.galaxies if g.redshift == 0.5][0].mass_0
+
+    assert isinstance(mass_back, ag.mp.PowerLawIntermediate)
+    assert mass_back.einstein_radius == pytest.approx(1.2, rel=1e-12)
+
+    grid = al.Grid2DIrregular([[1.0, 0.5], [-0.3, 0.7]])
+    tracer = al.Tracer(galaxies=galaxies)
+    assert np.asarray(
+        tracer_back.deflections_yx_2d_from(grid=grid)
+    ) == pytest.approx(np.asarray(tracer.deflections_yx_2d_from(grid=grid)), rel=1e-8)
+
+
 def test__round_trip__relative_file_path(tmp_path, monkeypatch):
     # The coolest JSONSerializer rejects relative paths — to_coolest /
     # from_coolest must absolutize them.


### PR DESCRIPTION
## Summary
Threads the new `intermediate` option (PyAutoLens#616) through `al.interop.coolest.from_coolest`: with `intermediate=True`, COOLEST `PEMD` profiles are rebuilt as `ag.mp.PowerLawIntermediate` — the template's `theta_E` becomes the profile's `einstein_radius` unchanged — instead of the default `ag.mp.PowerLaw` (identical mass distribution either way). Depends on the companion PyAutoGalaxy PR on the same branch (`feature/coolest-powerlaw-herculens`) — merge that first.

## API Changes
Added only — optional `intermediate: bool = False` kwarg on `from_coolest`; default behaviour unchanged.
See full details below.

## Test Plan
- [x] New test: export a `PowerLawIntermediate` model, `from_coolest(intermediate=True)` returns `PowerLawIntermediate` with the exact θ_E and identical tracer deflections.
- [x] Full suite: 387 passed.
- [ ] Follow-up in this task: herculens cross-code parity script in autolens_workspace_test.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autolens.interop.coolest.from_coolest(..., intermediate=False)` — new optional kwarg

</details>

Generated by the PyAutoLabs agent workflow.