### PR TITLE
refactor: use paths.preserve_in_zip for the positions cache (#1389 phase 2)

### DIFF
--- a/autolens/analysis/result.py
+++ b/autolens/analysis/result.py
@@ -313,11 +313,7 @@ class Result(AgResultDataset):
             # Preserve the cache in the search's zip — a resumed search's
             # paths.restore() wipes the output dir and re-extracts the zip,
             # destroying any file written only to files/ after completion.
-            from autogalaxy.analysis.adapt_images.adapt_images import (
-                _append_to_search_zip,
-            )
-
-            _append_to_search_zip(self.paths, cache_path)
+            self.paths.preserve_in_zip(cache_path)
 
         return positions
 

--- a/test_autolens/analysis/test_result.py
+++ b/test_autolens/analysis/test_result.py
@@ -389,6 +389,9 @@ def test__positions_likelihood_from__loads_cached_positions_on_second_call(
         def __init__(self, files_path):
             self._files_path = files_path
 
+        def preserve_in_zip(self, file_path):
+            """No zip in the stub — mirrors AbstractPaths' no-zip no-op."""
+
     tracer = al.Tracer(
         galaxies=[
             al.Galaxy(


### PR DESCRIPTION
## Summary

Phase 2 of PyAutoFit#1389 (autolens leg): the resume fast-path positions cache now calls the public `AbstractPaths.preserve_in_zip` (PyAutoFit#1390, merged) and the private cross-import of `_append_to_search_zip` from autogalaxy is removed. Behaviour identical — validated end-to-end via the `autolens_profiling` `pipeline_resume` recipe (cold 159s → resume ~11–13s).

## API Changes

None.

## Test Plan
- [x] `test_result.py` file green (stub gains the no-op method)
- [x] Full `test_autolens/` suite green

## Upstream PR

Merge the companion PyAutoGalaxy PR first (it deletes the helper this leg stops importing — merging this one first is also safe, but keep the pair ordered with #1389's checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
