### PR TITLE
fix: Marquardt-scaled LM damping + zero-fill correction profiles

### DIFF
--- a/autolens/potential_correction/dense_util.py
+++ b/autolens/potential_correction/dense_util.py
@@ -376,14 +376,20 @@ def lm_hessian_and_gradient_from(
 
 def solve_lm_step_from(H, minus_gradient, mu, constraint_matrix=None, x=None, xp=np):
     """
-    The damped LM step delta_x solving (H + mu I) dx = -g, or — when a
-    ``constraint_matrix`` C is given — the equality-constrained step via the
-    KKT system enforcing C (x + dx) = 0.
+    The damped LM step delta_x solving (H + mu D) dx = -g with Marquardt
+    scaling D = diag(diag(H)) (clipped below at the mean diagonal times
+    1e-12 so zero diagonal entries stay damped) — scale-invariant damping,
+    required when H's magnitude varies over many orders between datasets
+    (e.g. visibility-weighted interferometer curvatures ~1e11 vs imaging
+    ~1e4). When a ``constraint_matrix`` C is given, the equality-constrained
+    step solves the KKT system enforcing C (x + dx) = 0.
     """
     H_d = as_dense(H, xp=xp)
     g = xp.asarray(minus_gradient)
     n_x = H_d.shape[0]
-    H_lm = H_d + mu * xp.eye(n_x, dtype=H_d.dtype)
+    diag = xp.diag(H_d)
+    diag = xp.clip(diag, 1e-12 * xp.mean(xp.abs(diag)), None)
+    H_lm = H_d + mu * xp.diag(diag)
 
     if constraint_matrix is None:
         return xp.linalg.solve(H_lm, g)

--- a/autolens/potential_correction/iterative.py
+++ b/autolens/potential_correction/iterative.py
@@ -212,10 +212,14 @@ class IterFitDpsiSrcImaging:
         mask_dpsi_aa = self.pair_dpsi_data_obj.mask_dpsi_aa
         grid_dpsi = aa.Grid2D.from_mask(mask=mask_dpsi_aa)
 
+        # zero-fill extrapolation: the correction vanishes outside its mesh
+        # (nearest extrapolation would smear constant deflections across the
+        # full re-trace grid when the dpsi mesh is a sub-region of it)
         pix_mass_profile = InputPotential(
             lensing_potential=dpsi_vec,
             image_plane_grid=np.asarray(grid_dpsi),
             mask=mask_dpsi_aa,
+            extrapolate="zero",
         )
 
         lens_macro = self.lens_start

--- a/autolens/potential_correction/iterative_interferometer.py
+++ b/autolens/potential_correction/iterative_interferometer.py
@@ -230,10 +230,14 @@ class IterFitDpsiSrcInterferometer:
         mask_dpsi_aa = self.pair_dpsi_data_obj.mask_dpsi_aa
         grid_dpsi = aa.Grid2D.from_mask(mask=mask_dpsi_aa)
 
+        # zero-fill extrapolation: the correction vanishes outside its mesh
+        # (nearest extrapolation would smear constant deflections across the
+        # full re-trace grid when the dpsi mesh is a sub-region of it)
         pix_mass_profile = InputPotential(
             lensing_potential=dpsi_vec,
             image_plane_grid=np.asarray(grid_dpsi),
             mask=mask_dpsi_aa,
+            extrapolate="zero",
         )
 
         lens_macro = self.lens_start

--- a/test_autolens/potential_correction/test_dense_util.py
+++ b/test_autolens/potential_correction/test_dense_util.py
@@ -219,7 +219,8 @@ def test__solve_lm_step_from__unconstrained_and_constrained():
 
     mu = 0.7
     step = dense_util.solve_lm_step_from(H, minus_gradient, mu)
-    assert (H + mu * np.eye(H.shape[0])) @ step == pytest.approx(
+    diag = np.clip(np.diag(H), 1e-12 * np.mean(np.abs(np.diag(H))), None)
+    assert (H + mu * np.diag(diag)) @ step == pytest.approx(
         minus_gradient, rel=1.0e-8
     )
 


### PR DESCRIPTION
## Summary

Two robustness fixes to the potential-correction engines from the interferometer validation campaign (#623):

1. **Marquardt-scaled LM damping** in `dense_util.solve_lm_step_from`: the damped system is now `(H + μ·diag(diag(H)))·δx = −g` instead of `(H + μI)`, making the damping scale-invariant. With visibility-weighted curvatures (`H` ~ 10¹¹) the old μ·I damping had ~4 usable decades before the 10¹⁵ cap and the interferometer LM stalled with "damping exceeded"; with diagonal scaling the damping engages at every scale (the stall is gone). Zero diagonal entries are clipped to 1e-12 of the mean |diag| so they stay damped. Applies to both imaging and interferometer engines (imaging behaviour re-verified by the existing end-to-end tests).
2. **Zero-fill correction profiles**: both iterative engines now build their `InputPotential` with `extrapolate="zero"` (new PyAutoGalaxy mode, companion PR), so arc-restricted corrections vanish outside their mesh instead of nearest-smearing spurious deflections across the re-trace grid.

## API Changes

Behaviour change (internal numerics): the LM damping in `al.pc.dense_util.solve_lm_step_from` is now Marquardt-scaled; identical solutions at convergence, different damping trajectories. No signatures changed.
See full details below.

## Test Plan
- [x] `solve_lm_step_from` test updated to the Marquardt identity; constrained-step and all other kernel tests unchanged.
- [x] Full `test_autolens/potential_correction` suite: 51 passed (incl. both end-to-end iterative engines).
- [x] Full `test_autolens` suite run before commit.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `al.pc.dense_util.solve_lm_step_from(H, minus_gradient, mu, ...)` — damping term is now `mu * diag(diag(H))` (clipped) rather than `mu * I`.
- `al.pc.IterFitDpsiSrcImaging` / `IterFitDpsiSrcInterferometer` — correction `InputPotential` built with `extrapolate="zero"`.

### Migration
- None — no signature changes.

</details>

Generated by the PyAutoLabs agent workflow.
