### PR TITLE
Add opt-in gauge_project_x0 to the imaging iterative warm start

### DIFF
--- a/autolens/potential_correction/iterative.py
+++ b/autolens/potential_correction/iterative.py
@@ -354,7 +354,33 @@ class IterFitDpsiSrcImaging:
     # The Levenberg-Marquardt loop
     # -----------------------------
 
-    def solve_joint_optimization(self, xp=np, x0=None):
+    def _gauge_project_dpsi(self, dpsi_vec: np.ndarray) -> np.ndarray:
+        """
+        Project a dpsi vector onto the gauge-constrained subspace
+        <dpsi, 1> = <dpsi, x> = <dpsi, y> = 0 by removing its constant and
+        linear (deflection-drift) modes.
+
+        These modes are the null space of the Hamiltonian dpsi -> dkappa
+        map, so the projection leaves the physical convergence correction
+        unchanged. It is needed when warm-starting a ``gauge_constraints``
+        solve from an un-gauged ``x0`` (e.g. the one-shot
+        ``FitDpsiSrcImaging`` solution, which is not gauge-fixed). Each
+        accepted LM step re-imposes the gauge on the updated state
+        (C (x + dx) = 0), but from a near-optimal un-gauged start the
+        gauge-fixing move slides along the model-degenerate constant /
+        deflection-drift modes and so is not cost-decreasing: it is rejected
+        and the solve stalls off the constraint surface. Projecting ``x0``
+        up front places the warm start on the surface, where a cold start
+        from zero already begins.
+        """
+        dpsi_vec = np.asarray(dpsi_vec, dtype=float)
+        x = self.dpsi_points[:, 1]
+        y = self.dpsi_points[:, 0]
+        basis = np.column_stack([np.ones_like(x), x, y])
+        coeffs, *_ = np.linalg.lstsq(basis, dpsi_vec, rcond=None)
+        return dpsi_vec - basis @ coeffs
+
+    def solve_joint_optimization(self, xp=np, x0=None, gauge_project_x0=False):
         """
         Runs the Levenberg-Marquardt loop on the combined state
         x = [s | dpsi], accepting steps that decrease the penalized cost and
@@ -373,17 +399,32 @@ class IterFitDpsiSrcImaging:
             the one-shot ``FitDpsiSrcImaging``): the LM then refines inside
             that basin rather than searching from zero — the recipe
             certified by the interferometer uv campaign (PyAutoLens#627).
+        gauge_project_x0
+            When warm-starting a ``gauge_constraints`` solve, project the
+            dpsi component of ``x0`` onto the gauge subspace
+            <dpsi, 1> = <dpsi, x> = <dpsi, y> = 0 before iterating (see
+            :meth:`_gauge_project_dpsi`). Defaults to ``False`` (``x0`` used
+            verbatim); set ``True`` when ``x0`` is not itself gauge-fixed —
+            a near-optimal un-gauged start cannot reach the constraint
+            surface without a non-cost-decreasing move, which the LM
+            rejects, so it would otherwise stall with the gauge violated.
+            The dkappa recovery is unaffected by the projection.
         """
         n_s, n_dpsi = self._init_joint_optimization()
 
         if x0 is None:
             x = xp.zeros(n_s + n_dpsi)
         else:
-            x = xp.asarray(np.asarray(x0, dtype=float))
-            if x.shape != (n_s + n_dpsi,):
+            x0 = np.asarray(x0, dtype=float)
+            if x0.shape != (n_s + n_dpsi,):
                 raise ValueError(
-                    f"x0 has shape {x.shape}; expected ({n_s + n_dpsi},)"
+                    f"x0 has shape {x0.shape}; expected ({n_s + n_dpsi},)"
                 )
+            if gauge_project_x0:
+                x0 = np.concatenate(
+                    [x0[:n_s], self._gauge_project_dpsi(x0[n_s:])]
+                )
+            x = xp.asarray(x0)
 
         data_slim = xp.asarray(np.asarray(self.masked_imaging.data.slim))
         inv_var = xp.asarray(self.inverse_noise_variance)

--- a/test_autolens/potential_correction/test_iterative.py
+++ b/test_autolens/potential_correction/test_iterative.py
@@ -71,6 +71,53 @@ def test__solve_joint_optimization__gauge_constraints_are_satisfied(
     assert G @ dpsi_opt == pytest.approx(np.zeros(3), abs=1.0e-6)
 
 
+def test__gauge_project_dpsi__zeroes_the_three_functionals(masked_imaging_7x7):
+    fit = iter_fit_from(masked_imaging_7x7, gauge_constraints=True)
+    fit._init_joint_optimization()
+
+    x = fit.dpsi_points[:, 1]
+    y = fit.dpsi_points[:, 0]
+    n_dpsi = fit.dpsi_points.shape[0]
+
+    # an arbitrary field carrying a deliberate constant + linear (gauge) part
+    rng = np.random.default_rng(0)
+    dpsi = rng.standard_normal(n_dpsi) + 4.0 + 2.0 * x - 3.0 * y
+
+    projected = fit._gauge_project_dpsi(dpsi)
+
+    functionals = np.array(
+        [np.sum(projected), np.sum(x * projected), np.sum(y * projected)]
+    )
+    assert functionals == pytest.approx(np.zeros(3), abs=1.0e-8)
+    # removing only constant + linear modes: a already-gauged field is unchanged
+    assert fit._gauge_project_dpsi(projected) == pytest.approx(projected, abs=1.0e-8)
+
+
+def test__solve_joint_optimization__gauge_project_x0__gauges_an_ungauged_warm_start(
+    masked_imaging_7x7,
+):
+    # a cold solve gives a gauge-satisfied optimum; offset its dpsi by a pure
+    # constant to build a warm start that sits on the optimum but violates the
+    # <dpsi,1> constraint (an un-gauged x0, as the one-shot solution is).
+    fit0 = iter_fit_from(masked_imaging_7x7, gauge_constraints=True)
+    s_opt, dpsi_opt = fit0.solve_joint_optimization()
+    x0 = np.concatenate([s_opt, dpsi_opt + 0.7])
+
+    def gauge_of(fit, dpsi):
+        n_dpsi = dpsi.shape[0]
+        G = np.zeros((3, n_dpsi))
+        G[0, :] = 1.0 / n_dpsi
+        G[1, :] = fit.dpsi_points[:, 1] / n_dpsi
+        G[2, :] = fit.dpsi_points[:, 0] / n_dpsi
+        return G @ dpsi
+
+    assert np.abs(gauge_of(fit0, dpsi_opt + 0.7)[0]) > 1.0e-2  # x0 is un-gauged
+
+    fit_on = iter_fit_from(masked_imaging_7x7, gauge_constraints=True)
+    _, dpsi_on = fit_on.solve_joint_optimization(x0=x0, gauge_project_x0=True)
+    assert gauge_of(fit_on, dpsi_on) == pytest.approx(np.zeros(3), abs=1.0e-6)
+
+
 def test__log_evidence__finite_at_optimum(masked_imaging_7x7):
     fit = iter_fit_from(masked_imaging_7x7)
 


### PR DESCRIPTION
## Why

`ad97e5fd5` (interferometer PR #626) switched the shared imaging LM engine's damping to `mu*diag(H)`. Under scale-invariant damping, cold-starting `IterFitDpsiSrcImaging` from zeros no longer lands in the subhalo basin — the `autolens_workspace_test` regression `subhalo_recovery.py` collapsed from `corr 0.78` to a deterministic **`0.032`** (failing on main, 3.12 & 3.13, env-independent).

`#630` added an `x0` warm start as the certified recipe, but no test exercised it, and warm-starting a `gauge_constraints` solve from the (un-gauged) one-shot solution left the gauge `<dpsi,1> = <dpsi,x> = <dpsi,y> = 0` violated: each accepted LM step re-imposes the gauge on the updated state, but from a near-optimal un-gauged start the gauge-fixing move slides along the model-degenerate constant / deflection-drift modes and is not cost-decreasing, so the LM rejects it and stalls off the constraint surface.

## What

- New **`gauge_project_x0`** parameter on `IterFitDpsiSrcImaging.solve_joint_optimization` (**default `False`**, behaviour unchanged). When `True`, projects `x0`'s dpsi onto the gauge subspace before iterating, via the new `_gauge_project_dpsi`. The projected modes are the null space of the Hamiltonian `dpsi -> dkappa` map, so the recovered convergence correction is unchanged.
- Two new unit tests: functional zeroing of `_gauge_project_dpsi`, and an un-gauged near-optimal warm start ending gauge-satisfied. Full `test_autolens/potential_correction/` suite green (53 passed).

## Companion

`autolens_workspace_test` branch of the same name switches `subhalo_recovery.py` to `gauge_project_x0=True` (`corr 0.7822`, gauge satisfied). **Merge this library PR first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3MxfFWYP7cBPyLGE8MWAV