### PR TITLE
chore: rename PyAutoConf → PyAutoNerves in docs/prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ four layers below it — **autogalaxy**, **autoarray**, **autofit**, and
 
 ## Related repos
 
-- **Source siblings (all upstream):** PyAutoConf, PyAutoArray, PyAutoFit,
+- **Source siblings (all upstream):** PyAutoNerves, PyAutoArray, PyAutoFit,
   PyAutoGalaxy.
 - **autolens_workspace** — runnable tutorials/examples (`../autolens_workspace`).
 - **autolens_workspace_test** — integration + JAX/likelihood parity scripts.

--- a/docs/general/configs.md
+++ b/docs/general/configs.md
@@ -11,7 +11,7 @@ the [config directory of the workspace](https://github.com/PyAutoLabs/autolens_w
 By default, **PyAutoLens** looks for the config files in a `config` folder in the current working directory, which is
 why we run autolens scripts from the `autolens_workspace` directory.
 
-The configuration path can also be set manually in a script using the project **PyAutoConf** and the following
+The configuration path can also be set manually in a script using the project **PyAutoNerves** and the following
 command (the path to the `output` folder where the results of a non-linear search are stored is also set below):
 
 ```bash

--- a/docs/installation/overview.md
+++ b/docs/installation/overview.md
@@ -34,7 +34,7 @@ If you install **PyAutoLens** without a proper GPU setup, a warning will be disp
 
 **PyAutoLens** uses the following parent packages:
 
-**PyAutoConf** <https://github.com/PyAutoLabs/PyAutoConf>
+**PyAutoNerves** <https://github.com/PyAutoLabs/PyAutoNerves>
 
 **PyAutoFit** <https://github.com/PyAutoLabs/PyAutoFit>
 

--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -111,7 +111,7 @@ git clone https://github.com/PyAutoLabs/PyAutoGalaxy
 git clone https://github.com/PyAutoLabs/PyAutoLens
 ```
 
-Next, install **PyAutoConf** via pip:
+Next, install **PyAutoNerves** via pip:
 
 ```bash
 pip install autonerves

--- a/llms.txt
+++ b/llms.txt
@@ -17,4 +17,4 @@
 
 ## Ecosystem (libraries this builds on)
 
-- [PyAutoGalaxy](https://github.com/PyAutoLabs/PyAutoGalaxy), [PyAutoArray](https://github.com/PyAutoLabs/PyAutoArray), [PyAutoFit](https://github.com/PyAutoLabs/PyAutoFit), [PyAutoConf](https://github.com/PyAutoLabs/PyAutoConf): the upstream layers PyAutoLens is built on.
+- [PyAutoGalaxy](https://github.com/PyAutoLabs/PyAutoGalaxy), [PyAutoArray](https://github.com/PyAutoLabs/PyAutoArray), [PyAutoFit](https://github.com/PyAutoLabs/PyAutoFit), [PyAutoNerves](https://github.com/PyAutoLabs/PyAutoNerves): the upstream layers PyAutoLens is built on.


### PR DESCRIPTION
## What

Update the "source siblings / related repos" references from PyAutoConf to PyAutoNerves following the GitHub repo rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_