### PR TITLE
fix: PYAUTO_DISABLE_JAX has exactly one reader (#181 step 7)

### DIFF
--- a/autolens/analysis/analysis/dataset.py
+++ b/autolens/analysis/analysis/dataset.py
@@ -14,7 +14,6 @@ Abstract analysis class for fitting a ``Tracer`` to imaging or interferometer da
 """
 import logging
 import numpy as np
-import os
 from typing import List, Optional
 
 from autonerves import conf
@@ -84,11 +83,6 @@ class AnalysisDataset(AgAnalysisDataset, AnalysisLens):
             anyway.
         """
 
-        import os
-
-        if os.environ.get("PYAUTO_DISABLE_JAX") == "1":
-            use_jax = False
-
         super().__init__(
             dataset=dataset,
             adapt_images=adapt_images,
@@ -99,11 +93,15 @@ class AnalysisDataset(AgAnalysisDataset, AnalysisLens):
             **kwargs,
         )
 
+        # `super().__init__` routes through `af.Analysis.__init__`, the single
+        # reader of the disable-jax env var and the jax-availability check, which
+        # resolves `self._use_jax`. Forward that resolved value so `AnalysisLens`
+        # never overwrites it with the raw parameter.
         AnalysisLens.__init__(
             self=self,
             positions_likelihood_list=positions_likelihood_list,
             cosmology=cosmology,
-            use_jax=use_jax,
+            use_jax=self._use_jax,
         )
 
         self.raise_inversion_positions_likelihood_exception = (

--- a/autolens/analysis/analysis/lens.py
+++ b/autolens/analysis/analysis/lens.py
@@ -61,9 +61,11 @@ class AnalysisLens:
         self.cosmology = cosmology or Planck15()
         self.positions_likelihood_list = positions_likelihood_list
 
-        # Mirror the autofit Analysis fallback: if jax isn't installed,
-        # downgrade silently here too (the parent Analysis.__init__ already
-        # emitted the loud banner — no need to repeat it).
+        # `use_jax` is expected to already be the base-resolved value
+        # (`self._use_jax` set by `af.Analysis.__init__`, the single reader of
+        # the disable-jax env var and the jax-availability check). This guard is
+        # a defensive, idempotent re-check of jax availability only — it never
+        # re-reads the env var and does not repeat the parent's loud banner.
         import importlib.util
         if use_jax and importlib.util.find_spec("jax") is None:
             use_jax = False

--- a/autolens/point/model/analysis.py
+++ b/autolens/point/model/analysis.py
@@ -81,7 +81,10 @@ class AnalysisPoint(AgAnalysis, AnalysisLens):
         """
         super().__init__(cosmology=cosmology, use_jax=use_jax, **kwargs)
 
-        AnalysisLens.__init__(self=self, cosmology=cosmology, use_jax=use_jax)
+        # `super().__init__` (af.Analysis) is the single reader of the
+        # disable-jax env var + the jax-availability check; forward the
+        # resolved `self._use_jax` so `AnalysisLens` does not overwrite it.
+        AnalysisLens.__init__(self=self, cosmology=cosmology, use_jax=self._use_jax)
 
         self.dataset = dataset
 

--- a/autolens/weak/model/analysis.py
+++ b/autolens/weak/model/analysis.py
@@ -68,7 +68,10 @@ class AnalysisWeak(AgAnalysis, AnalysisLens):
         """
         super().__init__(cosmology=cosmology, use_jax=use_jax, **kwargs)
 
-        AnalysisLens.__init__(self=self, cosmology=cosmology, use_jax=use_jax)
+        # `super().__init__` (af.Analysis) is the single reader of the
+        # disable-jax env var + the jax-availability check; forward the
+        # resolved `self._use_jax` so `AnalysisLens` does not overwrite it.
+        AnalysisLens.__init__(self=self, cosmology=cosmology, use_jax=self._use_jax)
 
         self.dataset = dataset
 

--- a/test_autolens/analysis/analysis/test_analysis_dataset.py
+++ b/test_autolens/analysis/analysis/test_analysis_dataset.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import importlib.util
 import os
 import pytest
 
@@ -10,6 +11,37 @@ import autolens as al
 from autolens import exc
 
 directory = Path(__file__).resolve().parent
+
+
+def _jax_installed() -> bool:
+    return importlib.util.find_spec("jax") is not None
+
+
+def test__pyauto_disable_jax_env_downgrades_use_jax__imaging(
+    monkeypatch, masked_imaging_7x7
+):
+    # Regression cover for the deleted local env read in `AnalysisDataset`:
+    # the disable-jax env var must still downgrade `use_jax`, now resolved
+    # solely by `af.Analysis.__init__` (the single reader) and forwarded to
+    # `AnalysisLens` as `self._use_jax`.
+    monkeypatch.setenv("PYAUTO_DISABLE_JAX", "1")
+
+    analysis = al.AnalysisImaging(dataset=masked_imaging_7x7, use_jax=True)
+
+    assert analysis._use_jax is False
+
+
+@pytest.mark.skipif(not _jax_installed(), reason="jax not installed")
+def test__use_jax_true_env_unset__not_downgraded__imaging(
+    monkeypatch, masked_imaging_7x7
+):
+    # No over-downgrade: with the env var unset and jax installed,
+    # `use_jax=True` must survive as `self._use_jax is True`.
+    monkeypatch.delenv("PYAUTO_DISABLE_JAX", raising=False)
+
+    analysis = al.AnalysisImaging(dataset=masked_imaging_7x7, use_jax=True)
+
+    assert analysis._use_jax is True
 
 
 def test__modify_before_fit__inversion_no_positions_likelihood__raises_exception(

--- a/test_autolens/point/model/test_analysis_point.py
+++ b/test_autolens/point/model/test_analysis_point.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import importlib.util
+
+import pytest
 
 import autofit as af
 import autolens as al
@@ -6,6 +9,46 @@ import autolens as al
 from autolens.point.model.result import ResultPoint
 
 directory = Path(__file__).resolve().parent
+
+
+def _jax_installed() -> bool:
+    return importlib.util.find_spec("jax") is not None
+
+
+def test__pyauto_disable_jax_env_downgrades_use_jax__point(
+    monkeypatch, point_dataset
+):
+    # THE BUG TEST. Before the one-reader fix `AnalysisPoint` had no local
+    # env read and `AnalysisLens.__init__` overwrote the base-resolved
+    # `self._use_jax` with the raw `use_jax` parameter, so the disable-jax
+    # env var was silently a no-op (base set False, AnalysisLens set True).
+    # It must now downgrade to False.
+    monkeypatch.setenv("PYAUTO_DISABLE_JAX", "1")
+
+    solver = al.m.MockPointSolver(model_positions=point_dataset.positions)
+
+    analysis = al.AnalysisPoint(
+        dataset=point_dataset, solver=solver, use_jax=True
+    )
+
+    assert analysis._use_jax is False
+
+
+@pytest.mark.skipif(not _jax_installed(), reason="jax not installed")
+def test__use_jax_true_env_unset__not_downgraded__point(
+    monkeypatch, point_dataset
+):
+    # No over-downgrade: with the env var unset and jax installed,
+    # `use_jax=True` must survive as `self._use_jax is True`.
+    monkeypatch.delenv("PYAUTO_DISABLE_JAX", raising=False)
+
+    solver = al.m.MockPointSolver(model_positions=point_dataset.positions)
+
+    analysis = al.AnalysisPoint(
+        dataset=point_dataset, solver=solver, use_jax=True
+    )
+
+    assert analysis._use_jax is True
 
 
 def _test__make_result__result_imaging_is_returned(point_dataset):


### PR DESCRIPTION
## Summary
Step 7 of the env-profile migration (PyAutoHands#181; design `PyAutoHands/docs/env_profile_redesign.md` §5, failure mode 8): `PYAUTO_DISABLE_JAX` now has **exactly one reader** — `af.Analysis.__init__`. `AnalysisLens.__init__` receives the base-resolved `self._use_jax` instead of the raw parameter at all three call sites, and `AnalysisDataset`'s duplicate pre-`super()` env read is deleted.

This also **fixes a live bug**: `AnalysisPoint` and the weak analysis passed the raw `use_jax` to `AnalysisLens`, whose assignment overwrites the base class's resolution — so `PYAUTO_DISABLE_JAX=1` was silently undone for them (they ran JAX in the nightly by accident). `AnalysisDataset` masked the same overwrite with its duplicate read, which also skipped the jax-not-installed downgrade the base applies — `AnalysisLens` could disagree with `self._use_jax` there.

## API Changes
None — internal behaviour fix. Public signatures unchanged. Behavioural change only under `PYAUTO_DISABLE_JAX=1` (release validation): point/weak analyses now honour the downgrade as designed.

## Test Plan
- [x] New construction-level tests (NumPy-only): imaging + point downgrade under env=1, no over-downgrade with env unset — **red-green proven** (the point test fails on pre-fix source: `_use_jax` was `True` despite env=1; passes after)
- [x] `test_autolens/analysis` 59 passed; `test_autolens/point` 60 passed
- [x] `grep -rn PYAUTO_DISABLE_JAX autolens/` → empty (only reader is the PyAutoFit base class)
- [x] **Nightly-impact triage**: exactly one release script flips JAX→NumPy (`autolens_workspace_test/scripts/point_source/visualization.py` — unmarked; every other point/weak script is `jax_`-marked or no_run'd; user workspaces pin `PYAUTO_DISABLE_JAX: "0"` so are untouched). Ran it under its exact NumPy release env with this branch on PYTHONPATH: **pass, 8 s**.

## Heart gate
Continuation of today's #181 work under the same human-acknowledged pre-existing RED. No downstream workspace edits required.

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
