### PR TITLE
docs: make getting started assistant-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,26 +23,16 @@ When two or more galaxies are aligned perfectly down our line-of-sight, the back
 
 This is called strong gravitational lensing and **PyAutoLens** makes it **simple** to model strong gravitational lenses, using JAX to **accelerate lens modeling on GPUs**.
 
-> 🤖 **AI-assisted use:** you can also learn and drive **PyAutoLens** with AI — either a browser chat assistant (ChatGPT, Claude) pointed at [**autolens_assistant**](https://github.com/PyAutoLabs/autolens_assistant), or a fully agentic coding tool (Claude Code, Codex) that runs lens modeling end-to-end on your machine. See the **Three Ways to Learn PyAutoLens** section below.
-
 ## Getting Started
 
-The following links are useful for new starters:
+The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the assistant for its full scope and instructions.
+
+The following human-readable documentation and examples are also useful for new starters:
 
 - [The PyAutoLens readthedocs](https://pyautolens.readthedocs.io/en/latest): which includes [an overview of PyAutoLens's core features](https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html).
 - [The introduction Jupyter Notebook on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb): try **PyAutoLens** in a web browser (without installation).
 - [The autolens_workspace GitHub repository](https://github.com/PyAutoLabs/autolens_workspace): example scripts covering every **PyAutoLens** use case.
 - [The HowToLens GitHub repository](https://github.com/PyAutoLabs/HowToLens): a Jupyter notebook lecture series teaching strong lensing and lens modeling from the ground up.
-
-## Three Ways to Learn PyAutoLens
-
-There are three ways to learn how to use **PyAutoLens**, which you can freely mix and match:
-
-1. **Manual navigation** — read the workspace guides yourself, starting from the [new user guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and the `start_here` notebooks, which are organised by lens scale and dataset type.
-2. **AI chat assistant** — ask questions to a conversational AI assistant such as ChatGPT or Claude in the browser. Go to the [autolens_assistant](https://github.com/PyAutoLabs/autolens_assistant) repository and copy the ready-to-use example prompt from its README into ChatGPT or Claude to get started. This is ideal for learning the API, working out how to perform a calculation, and creating end-to-end example Python scripts.
-3. **Fully agentic AI** — drive **PyAutoLens** end-to-end with an agentic coding tool such as [Claude Code](https://claude.com/claude-code) or [Codex](https://developers.openai.com/codex) together with [autolens_assistant](https://github.com/PyAutoLabs/autolens_assistant). These can inspect your data, write and run scripts, and manage a lens-modeling project directly on your machine.
-
-See [autolens_assistant](https://github.com/PyAutoLabs/autolens_assistant) for more on the AI-assisted options (2 and 3).
 
 ## Community & Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,13 +8,11 @@ When two or more galaxies are aligned perfectly down our line-of-sight, the back
 
 This is called strong gravitational lensing and **PyAutoLens** makes it simple to model strong gravitational lenses, using JAX to **accelerate lens modeling on GPUs**.
 
-```{note}
-🤖 **AI-assisted use:** alongside reading the guides, you can learn and drive **PyAutoLens** with AI — either a browser chat assistant (ChatGPT, Claude) pointed at [autolens_assistant](https://github.com/PyAutoLabs/autolens_assistant), or a fully agentic coding tool (Claude Code, Codex) that runs lens modeling end-to-end on your machine. The [new user guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) describes all three ways to learn.
-```
-
 # Getting Started
 
-The following links are useful for new starters:
+The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the assistant for its full scope and instructions.
+
+The following human-readable documentation and examples are also useful for new starters:
 
 - [The PyAutoLens readthedocs](https://pyautolens.readthedocs.io/en/latest): which includes [an overview of PyAutoLens's core features](https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html).
 - [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb), where you can try **PyAutoLens** in a web browser (without installation).

--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -7,27 +7,11 @@ different types of data (e.g. imaging, interferometer, and point-source observat
 
 The autolens_workspace contains a suite of example Jupyter Notebooks, organised by lens scale and dataset type.
 
-## Three Ways To Learn PyAutoLens
+## AI Assistant
 
-There are three ways to learn how to use **PyAutoLens**, which you are free to mix and match:
+The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the assistant for its full scope and instructions.
 
-1. **Manual Navigation**: Read the workspace guides yourself. To find the example notebook best suited to your
-   science case, work through the two questions below ("What Scale Lens?" and "What Dataset Type?"), which point you
-   to the right starting point. This is the traditional route, and the rest of this guide supports it.
-
-2. **AI Chat Assistant**: Ask questions to a conversational AI assistant such as ChatGPT or Claude in the browser.
-   Go to the [autolens_assistant](https://github.com/PyAutoLabs/autolens_assistant) repository and copy the ready-to-use
-   example prompt from its README into ChatGPT or Claude — it gets you asking useful questions from the very first
-   message. This is ideal for learning the API, working out how to perform a calculation, and creating end-to-end
-   example Python scripts.
-
-3. **Fully Agentic AI**: Use an agentic coding tool such as [Claude Code](https://claude.com/claude-code) or
-   [Codex](https://developers.openai.com/codex) together with [autolens_assistant](https://github.com/PyAutoLabs/autolens_assistant).
-   These can inspect your data, write and run scripts, and manage an end-to-end lens modeling project directly on your
-   machine. See the [autolens_assistant](https://github.com/PyAutoLabs/autolens_assistant) repository for more information.
-
-The rest of this guide supports **manual navigation**: we begin by answering two simple questions to find your most
-appropriate starting point.
+The rest of this human-readable guide begins with two simple questions to help you find the most appropriate example notebook for your science case.
 
 ## What Scale Lens?
 


### PR DESCRIPTION
## Summary
- Put the PyAutoLens AI Assistant first in README and Read the Docs getting-started guidance.
- Present conversation agents and coding agents as two ways to use one assistant.
- Remove the duplicated “Three Ways to Learn PyAutoLens” framing while preserving human-readable docs, examples, and Colab links.

## API Changes
None — internal changes only. Documentation wording only; the public Python API is unchanged. See full details below.

## Test Plan
- [x] `python -m pytest test_autolens/ -x`
- [x] `python -m sphinx --keep-going -b html docs <temporary-output-directory>`
- [x] Confirmed the scoped files contain none of the retired chat/agentic/Three Ways terminology
- [x] Confirmed `https://github.com/PyAutoLabs/autolens_assistant` resolves successfully

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- None.

### Renamed
- None.

### Changed Signature
- None.

### Changed Behaviour
- None.

### Migration
- None required.

</details>

Generated by the PyAutoLabs agent workflow.
