### PR TITLE
docs: clarify assistant and documentation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ This is called strong gravitational lensing and **PyAutoLens** makes it **simple
 
 ## Getting Started
 
+### PyAutoLens AI Assistant
+
 The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the assistant for its full scope and instructions.
+
+### Human-Readable Documentation and Examples
 
 The following human-readable documentation and examples are also useful for new starters:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,11 @@ This is called strong gravitational lensing and **PyAutoLens** makes it simple t
 
 # Getting Started
 
+## PyAutoLens AI Assistant
+
 The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the assistant for its full scope and instructions.
+
+## Human-Readable Documentation and Examples
 
 The following human-readable documentation and examples are also useful for new starters:
 

--- a/docs/overview/overview_1_start_here.md
+++ b/docs/overview/overview_1_start_here.md
@@ -2,6 +2,12 @@
 
 # Start Here
 
+## PyAutoLens AI Assistant
+
+The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the assistant for its full scope and instructions.
+
+## Human-Readable Overview
+
 **PyAutoLens** is software for analysing strong gravitational lenses, an astrophysical phenomenon where a galaxy
 appears multiple times because its light is bent by the gravitational field of an intervening foreground lens galaxy.
 

--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -2,16 +2,18 @@
 
 # New User Guide
 
+## PyAutoLens AI Assistant
+
+The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the assistant for its full scope and instructions.
+
+## Human-Readable Guide
+
 **PyAutoLens** can analyse strong lens systems across a range of physical scales (e.g. galaxy, group, and cluster) and for
 different types of data (e.g. imaging, interferometer, and point-source observations). Depending on the scientific questions you are interested in, the analysis you perform may differ significantly.
 
 The autolens_workspace contains a suite of example Jupyter Notebooks, organised by lens scale and dataset type.
 
-## AI Assistant
-
-The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the assistant for its full scope and instructions.
-
-The rest of this human-readable guide begins with two simple questions to help you find the most appropriate example notebook for your science case.
+This guide begins with two simple questions to help you find the most appropriate example notebook for your science case.
 
 ## What Scale Lens?
 


### PR DESCRIPTION
## Summary
- separate the PyAutoLens AI Assistant and human-readable documentation into clearly headed onboarding routes
- put the AI Assistant first on the Read the Docs Start Here page
- split assistant guidance from the conventional New User Guide content

## API Changes
None — documentation-only changes.

## Test Plan
- [x] `git diff --check`
- [x] `python -m sphinx -b html docs /tmp/assistant_docs_hierarchy_pyautolens`
- [x] `python -m pytest test_autolens/ -x`
- [x] Confirm generated HTML contains the new headings in the intended order

Generated by the PyAutoLabs agent workflow.
