### PR TITLE
fix: skip the JAX-only sparse-operator tests where jax is unavailable

### DIFF
--- a/test_autolens/potential_correction/test_fit_interferometer.py
+++ b/test_autolens/potential_correction/test_fit_interferometer.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 import numpy as np
 import pytest
 
@@ -5,6 +7,17 @@ import autoarray as aa
 import autolens as al
 from autolens.potential_correction.fit_interferometer import (
     FitDpsiSrcInterferometer,
+)
+
+# `apply_sparse_operator` is a JAX-only code path: `InterferometerSparseOperator`
+# builds its FFT kernel with `jax.numpy` and projects with `jax.ops.segment_sum`
+# / `jax.lax`, with no NumPy equivalent. `autonerves[jax]` gates jax to
+# Python >= 3.11, so the sparse-route case cannot run on the 3.9/3.10 matrix
+# legs — skip it there rather than fail. The dense-route cases stay NumPy-only
+# and run everywhere, which is what those legs exist to prove.
+requires_jax = pytest.mark.skipif(
+    importlib.util.find_spec("jax") is None,
+    reason="apply_sparse_operator is a JAX-only path; jax requires Python >= 3.11",
 )
 
 
@@ -50,6 +63,7 @@ def test__dense_route__end_to_end_evidence_is_finite(interferometer_7):
     )
 
 
+@requires_jax
 def test__sparse_route__matches_dense_route(interferometer_7):
     dataset_sparse = interferometer_7.apply_sparse_operator()
 

--- a/test_autolens/potential_correction/test_iterative_interferometer.py
+++ b/test_autolens/potential_correction/test_iterative_interferometer.py
@@ -1,8 +1,21 @@
+import importlib.util
+
 import numpy as np
 import pytest
 
 import autoarray as aa
 import autolens as al
+
+# `apply_sparse_operator` is a JAX-only code path: `InterferometerSparseOperator`
+# builds its FFT kernel with `jax.numpy` and projects with `jax.ops.segment_sum`
+# / `jax.lax`, with no NumPy equivalent. `autonerves[jax]` gates jax to
+# Python >= 3.11, so the cases below cannot run on the 3.9/3.10 matrix legs —
+# skip them there rather than fail. The dense-route cases stay NumPy-only and
+# run everywhere, which is what those legs exist to prove.
+requires_jax = pytest.mark.skipif(
+    importlib.util.find_spec("jax") is None,
+    reason="apply_sparse_operator is a JAX-only path; jax requires Python >= 3.11",
+)
 
 
 def iter_fit_from(dataset, gauge_constraints=False, n_iter=2):
@@ -33,6 +46,7 @@ def test__requires_sparse_operator(interferometer_7):
         iter_fit_from(interferometer_7)
 
 
+@requires_jax
 def test__solve_joint_optimization__finite_state_and_decreasing_cost(
     interferometer_7,
 ):
@@ -56,6 +70,7 @@ def test__solve_joint_optimization__finite_state_and_decreasing_cost(
     assert cost_opt < 0.5 * fit.data_weighted_norm
 
 
+@requires_jax
 def test__cost_identity_matches_direct_visibility_chi2(interferometer_7):
     """
     The normal-equation chi^2 identity (d^H C^-1 d - 2 x^T D + x^T F x) must
@@ -88,6 +103,7 @@ def test__cost_identity_matches_direct_visibility_chi2(interferometer_7):
     assert chi2_half == pytest.approx(chi2_direct, rel=1e-3)
 
 
+@requires_jax
 def test__gauge_constraints_are_satisfied(interferometer_7):
     dataset = interferometer_7.apply_sparse_operator()
     fit = iter_fit_from(dataset, gauge_constraints=True)
@@ -103,6 +119,7 @@ def test__gauge_constraints_are_satisfied(interferometer_7):
     assert G @ dpsi_opt == pytest.approx(np.zeros(3), abs=1.0e-6)
 
 
+@requires_jax
 def test__log_evidence__finite_at_optimum(interferometer_7):
     dataset = interferometer_7.apply_sparse_operator()
     fit = iter_fit_from(dataset)


### PR DESCRIPTION
Fixes the `unit_tests (3.9, PyAutoLens)` and `(3.10, PyAutoLens)` legs of `PyAutoHands/python_matrix`, red on the schedule (pre-existing — present in the 2026-07-20 and 2026-07-27 runs).

## The failure

5 failures, all the same:

```
ModuleNotFoundError: No module named 'jax'
  ../PyAutoArray/autoarray/dataset/interferometer/dataset.py:280: in apply_sparse_operator
  ../PyAutoArray/.../inversion_interferometer_util.py:654: in from_nufft_precision_operator
      import jax.numpy as jnp
```

## Why this is a test-placement problem, not a library bug

The sparse-operator subsystem is **JAX-only by design**:

- `InterferometerSparseOperator` builds its FFT kernel with `jax.numpy` (`from_nufft_precision_operator`), applies it with `jax.numpy` (`apply_operator`), and projects with `jax.ops.segment_sum` + `jax.lax` (`curvature_matrix_diag_from`) — three jax sites, no NumPy equivalent.
- The imaging counterpart has 8+ jax sites and types a field literally as `"jax.Array"`.
- `autonerves[jax]` gates jax to `python_version >= '3.11'`, so 3.9/3.10 have no jax by construction.

The 5 failing cases are exactly those calling `apply_sparse_operator()` — i.e. tests **of** the JAX feature, running in matrix legs that deliberately have no jax.

A NumPy fallback was considered and rejected: it would mean reimplementing the whole sparse-operator path (`segment_sum` → `np.add.at`/`bincount`, dropping `lax`), a substantial new feature with real numerical-parity risk, to serve Pythons the feature is not gated for.

## Change

A `find_spec`-based `skipif` marker applied to exactly those 5 cases, matching the `pytest.importorskip` idiom already used in `test_autolens/interop/test_coolest.py`.

Deliberately **per-test, not module-level**: the dense-route cases in the same files (`test__dense_route__end_to_end_evidence_is_finite`, `test__sparse_route__requires_sparse_operator`, `test__evidence_terms__match_hand_computed_dense_formulation`, `test__requires_sparse_operator`) are NumPy-only and must keep running on 3.9/3.10 — that is what those legs exist to prove. A module-level skip would have silently dropped them.

This also restores the standing **"library unit tests are NumPy-only"** rule for these files.

## Verification

```
jax present -> 9 passed, 0 skipped
jax absent  -> 4 passed, 5 skipped
```

The absent case was produced by shimming `importlib.util.find_spec("jax") -> None`, and the 5 skips are exactly the 5 CI failures — no more, no less.

## Scope note

This is the **second** cause of `python_matrix` being red. The first — `nufftax` on the 3.11 `autolens_workspace` smoke leg — was already fixed on `autolens_workspace` main by #351 earlier today; a verification dispatch is in flight.
