### PR TITLE
feat: require Python 3.12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest t
 
 PRs must pass `pytest --cov` on the CI matrix (Python 3.12 **and** 3.13). There
 is no black/ruff/flake8 gate — formatting is advisory. (`requires-python` in
-`pyproject.toml` is `>=3.9`.)
+`pyproject.toml` is `>=3.12`.)
 
 ## Configuration & defaults
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description="Open-Source Strong Lensing"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 authors = [
     { name = "James Nightingale", email = "James.Nightingale@newcastle.ac.uk" },
     { name = "Richard Hayes", email = "richard@rghsoftware.co.uk" },
@@ -18,9 +18,6 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
   "Natural Language :: English",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13"
 ]

--- a/test_autolens/potential_correction/test_fit_interferometer.py
+++ b/test_autolens/potential_correction/test_fit_interferometer.py
@@ -11,13 +11,11 @@ from autolens.potential_correction.fit_interferometer import (
 
 # `apply_sparse_operator` is a JAX-only code path: `InterferometerSparseOperator`
 # builds its FFT kernel with `jax.numpy` and projects with `jax.ops.segment_sum`
-# / `jax.lax`, with no NumPy equivalent. `autonerves[jax]` gates jax to
-# Python >= 3.11, so the sparse-route case cannot run on the 3.9/3.10 matrix
-# legs — skip it there rather than fail. The dense-route cases stay NumPy-only
-# and run everywhere, which is what those legs exist to prove.
+# / `jax.lax`, with no NumPy equivalent. Skip the sparse-route case when the
+# optional JAX dependency is not installed. The dense route stays NumPy-only.
 requires_jax = pytest.mark.skipif(
     importlib.util.find_spec("jax") is None,
-    reason="apply_sparse_operator is a JAX-only path; jax requires Python >= 3.11",
+    reason="apply_sparse_operator requires the optional JAX dependency",
 )
 
 

--- a/test_autolens/potential_correction/test_iterative_interferometer.py
+++ b/test_autolens/potential_correction/test_iterative_interferometer.py
@@ -8,13 +8,11 @@ import autolens as al
 
 # `apply_sparse_operator` is a JAX-only code path: `InterferometerSparseOperator`
 # builds its FFT kernel with `jax.numpy` and projects with `jax.ops.segment_sum`
-# / `jax.lax`, with no NumPy equivalent. `autonerves[jax]` gates jax to
-# Python >= 3.11, so the cases below cannot run on the 3.9/3.10 matrix legs —
-# skip them there rather than fail. The dense-route cases stay NumPy-only and
-# run everywhere, which is what those legs exist to prove.
+# / `jax.lax`, with no NumPy equivalent. Skip these cases when the optional JAX
+# dependency is not installed. The dense-route cases stay NumPy-only.
 requires_jax = pytest.mark.skipif(
     importlib.util.find_spec("jax") is None,
-    reason="apply_sparse_operator is a JAX-only path; jax requires Python >= 3.11",
+    reason="apply_sparse_operator requires the optional JAX dependency",
 )
 
 


### PR DESCRIPTION
## Summary
Raise PyAutoLens's minimum supported Python version to 3.12 and advertise only Python 3.12 and 3.13.

Remove obsolete pre-3.12 explanations from the optional-JAX potential-correction test guards while preserving their dependency-based skip behavior.

Refs #663.

## API Changes
Public Python symbols and signatures are unchanged. Installation now requires Python 3.12 or newer. The affected tests still skip JAX-only sparse-operator paths when the optional JAX dependency is unavailable.

## Test Plan
- [x] Full Python 3.12 suite: 488 passed
- [x] Package metadata declares `Requires-Python: >=3.12` and only Python 3.12/3.13 classifiers
- [x] `git diff --check`
- [x] Committed tree is byte-identical to immutable Opus-CLEAN review commit `83b157014`
- [x] Exact four-file diff from base `0612f3e0357be916293449ea26b1f4c083482713`

## Release Status
No release or merge was performed. This PR is queued with the `pending-release` label, and issue #663 remains open for human-controlled campaign completion.

Generated by the PyAutoLabs agent workflow.
