### PR TITLE
feat: export subplot_interferometer_dataset + subplot_fit_interferometer_combined

### DIFF
--- a/autolens/plot/__init__.py
+++ b/autolens/plot/__init__.py
@@ -17,6 +17,7 @@ from autoarray.dataset.plot.imaging_plots import (
     fits_imaging,
 )
 from autoarray.dataset.plot.interferometer_plots import (
+    subplot_interferometer_dataset,
     subplot_interferometer_dirty_images,
     fits_interferometer,
 )
@@ -60,6 +61,7 @@ from autolens.interferometer.plot.fit_interferometer_plots import (
     subplot_fit as subplot_fit_interferometer,
     subplot_fit_real_space as subplot_fit_interferometer_real_space,
     subplot_tracer_from_fit as subplot_fit_interferometer_tracer,
+    subplot_fit_interferometer_combined,
 )
 from autolens.point.plot.fit_point_plots import subplot_fit as subplot_fit_point
 from autolens.point.plot.point_dataset_plots import subplot_dataset as subplot_point_dataset

--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -50,13 +50,15 @@ Create figures and subplots showing quantities of standard **PyAutoLens** object
     subplot_fit_combined
     subplot_fit_combined_log10
 
-**Interferometer Fit Subplots:**
+**Interferometer Subplots:**
 
 .. autosummary::
    :toctree: _autosummary
 
+    subplot_interferometer_dataset
     subplot_fit_interferometer
     subplot_fit_interferometer_real_space
+    subplot_fit_interferometer_combined
 
 **Point Source Subplots:**
 


### PR DESCRIPTION
## Summary

`autolens.plot` was missing two interferometer plotting symbols that exist and are reachable everywhere else in the stack. This adds them as pure re-exports.

- **`subplot_interferometer_dataset`** — `autogalaxy.plot` exports it from `autoarray.dataset.plot.interferometer_plots`, but `autolens.plot` imported only `subplot_interferometer_dirty_images` and `fits_interferometer` from that same module and skipped it. The interferometer *dataset* subplot was therefore unreachable from `autolens.plot`, which is why `autolens_workspace/scripts/interferometer/plot.py` has no dataset subplot while its autogalaxy counterpart does. That was never a workspace gap — the function simply could not be called.
- **`subplot_fit_interferometer_combined`** — autolens's own function in `autolens/interferometer/plot/fit_interferometer_plots.py`, left unexported while the imaging equivalent `subplot_fit_combined` **is** exported.

This is the mirror of PyAutoGalaxy#538, which closed the same export asymmetry in the other direction during the `plot-guides-restructure` task.

Found by an audit of every public function in the source `*_plots.py` modules against every `aplt.*` call in both workspaces — the same audit that drives the workspace follow-up (see #667).

## API Changes

Two symbols added to the `autolens.plot` (`aplt`) namespace. Both are re-exports of existing, unchanged functions — no signature, behaviour, or resolution change to anything already exported. Nothing removed or renamed.

See full details below.

## Test Plan

- [x] Full PyAutoLens suite inside the task worktree: **488 passed, 0 failed** (66.75s)
- [x] `set(dir(autogalaxy.plot)) - set(dir(autolens.plot))` reduces from `{subplot_fit_imaging_list, subplot_interferometer_dataset}` to just `{subplot_fit_imaging_list}` (deliberate — AL uses `subplot_fit_combined` instead of AG's `subplot_fit_imaging_list`)
- [x] Both new names resolve to the expected modules, asserted against the worktree copy of `autolens` rather than the installed stack:
  - `subplot_interferometer_dataset` → `autoarray.dataset.plot.interferometer_plots`
  - `subplot_fit_interferometer_combined` → `autolens.interferometer.plot.fit_interferometer_plots` (autolens's own, **not** autogalaxy's)
- [x] `aplt` export count 61 → 63
- [x] `git diff --stat` = 2 files, 5 insertions, 1 deletion — no binary or output leakage

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added

- `autolens.plot.subplot_interferometer_dataset(dataset, output_path=, output_filename="dataset", output_format=, colormap=, use_log10=False, title_prefix=)` — multi-panel subplot of an interferometer dataset. Re-export of `autoarray.dataset.plot.interferometer_plots.subplot_interferometer_dataset`, already exported by `autogalaxy.plot`.
- `autolens.plot.subplot_fit_interferometer_combined(fit_list, output_path=, output_format=, colormap=, title_prefix=)` — combined subplot across a list of interferometer fits. Re-export of `autolens.interferometer.plot.fit_interferometer_plots.subplot_fit_interferometer_combined`.

### Removed

None.

### Renamed

None.

### Changed Signature

None.

### Changed Behaviour

None. In particular, the names `subplot_fit_dirty_images` and `subplot_fit_real_space` continue to resolve to the **autogalaxy** implementations inside `autolens.plot`, exactly as before this PR.

### Migration

None required — additive only. Previously unreachable calls now work:

- Before: `aplt.subplot_interferometer_dataset(dataset=dataset)` → `AttributeError`
- After: renders the interferometer dataset subplot, matching `autogalaxy.plot`.

</details>

<details>
<summary>Deliberately out of scope</summary>

**Not changed here:** `aplt.subplot_fit_dirty_images` and `aplt.subplot_fit_real_space` resolve to the **autogalaxy** implementations inside `autolens.plot`, shadowing autolens's own versions in `autolens/interferometer/plot/fit_interferometer_plots.py` — which accept lensing-specific `image_plane_lines` / `source_plane_lines` arguments the autogalaxy versions do not. Rebinding an existing exported name is a behaviour change, not an additive export, so it belongs in its own prompt rather than riding along here.

**Pre-existing `docs/api/plot.rst` omissions**, not fixed in this PR: `subplot_imaging_dataset`, `subplot_imaging_dataset_list`, `fits_imaging`, `fits_interferometer`, `subplot_fit_interferometer_tracer` and `subplot_interferometer_dirty_images` are all exported but absent from the API docs. Separate audit.

</details>

## Follow-up

The workspace leg of #667 lands after this merges: 7 `plot.py` files across `autolens_workspace` (imaging, interferometer, weak, cluster, point_source) and `autogalaxy_workspace` (imaging, interferometer). The AL interferometer dataset subplot depends on the first export here.

Closes nothing on its own — #667 stays open until the workspace leg ships.

Generated by the PyAutoLabs agent workflow.
