### PR TITLE
feat: export subplot_fit_interferometer_dirty_images (autolens's own)

### DIFF
--- a/autolens/plot/__init__.py
+++ b/autolens/plot/__init__.py
@@ -60,6 +60,7 @@ from autolens.imaging.plot.fit_imaging_plots import (
 from autolens.interferometer.plot.fit_interferometer_plots import (
     subplot_fit as subplot_fit_interferometer,
     subplot_fit_real_space as subplot_fit_interferometer_real_space,
+    subplot_fit_dirty_images as subplot_fit_interferometer_dirty_images,
     subplot_tracer_from_fit as subplot_fit_interferometer_tracer,
     subplot_fit_interferometer_combined,
 )

--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -58,6 +58,7 @@ Create figures and subplots showing quantities of standard **PyAutoLens** object
     subplot_interferometer_dataset
     subplot_fit_interferometer
     subplot_fit_interferometer_real_space
+    subplot_fit_interferometer_dirty_images
     subplot_fit_interferometer_combined
 
 **Point Source Subplots:**


### PR DESCRIPTION
## Summary

Follow-up 4 from #667 — a live API defect.

`aplt.subplot_fit_dirty_images` resolves to the **autogalaxy** implementation inside `autolens.plot`:

```python
>>> aplt.subplot_fit_dirty_images.__module__
'autogalaxy.interferometer.plot.fit_interferometer_plots'
```

autolens has its own version in `autolens/interferometer/plot/fit_interferometer_plots.py`, and it was reachable under **no exported name at all**.

That version is not merely a duplicate. When `image_plane_lines is None` it auto-derives the tracer's critical curves from the fit and overlays them on the dirty model image — lensing information the autogalaxy version cannot produce. Lens users calling `aplt.subplot_fit_dirty_images` were silently getting the galaxy version and losing that overlay.

## API Changes

One symbol added: `subplot_fit_interferometer_dirty_images`, bound to autolens's own function. Purely additive — nothing removed, renamed, or resignatured.

`subplot_fit_dirty_images` is **deliberately left bound to the autogalaxy version**. The two signatures diverge (`residuals_symmetric_cmap` on the AG side, `image_plane_lines` / `image_plane_line_colors` on the AL side), so rebinding it would be a behaviour change, not an additive export.

This matches the convention already in the file: `subplot_fit_real_space` (autogalaxy) coexists with `subplot_fit_interferometer_real_space` (autolens's own). `subplot_fit_dirty_images` had simply never been given its `subplot_fit_interferometer_*` counterpart.

See full details below.

## Test Plan

- [x] Full PyAutoLens suite: **488 passed, 0 failed** (55.7s)
- [x] Additivity asserted programmatically against the branch build — new name resolves to `autolens.…`, old name still resolves to `autogalaxy.…`:
  - `subplot_fit_interferometer_dirty_images` → `autolens.interferometer.plot.fit_interferometer_plots`
  - `subplot_fit_dirty_images` → `autogalaxy.interferometer.plot.fit_interferometer_plots` (unchanged)
- [x] Functionally exercised on a real `FitInterferometer`, not just signature-checked: the new export renders and auto-derives **1** critical curve via `_compute_critical_curve_lines`; the old export still renders unchanged.
- [x] `git diff --stat` = 2 files, 2 insertions, 0 deletions

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added

- `autolens.plot.subplot_fit_interferometer_dirty_images(fit, output_path=, output_format=, colormap=, use_log10=False, image_plane_lines=, image_plane_line_colors=, title_prefix=)` — 2×3 subplot of dirty-image diagnostics for an interferometer fit, overlaying the tracer's critical curves on the dirty model image. Auto-derives the curves from the fit when `image_plane_lines` is `None`. Re-export of `autolens.interferometer.plot.fit_interferometer_plots.subplot_fit_dirty_images`.

### Removed / Renamed / Changed Signature / Changed Behaviour

None. `subplot_fit_dirty_images` continues to resolve to the autogalaxy implementation exactly as before.

### Migration

None required. Lens users wanting the critical-curve overlay switch call sites:

- Before: `aplt.subplot_fit_dirty_images(fit=fit)` — galaxy version, no overlay
- After: `aplt.subplot_fit_interferometer_dirty_images(fit=fit)` — overlay auto-derived

</details>

<details>
<summary>Deferred: the 11 existing workspace call sites</summary>

`autolens_workspace` calls `aplt.subplot_fit_dirty_images` at 11 sites (`scripts/interferometer/{fit,modeling,plot}.py`, four `interferometer/features/*/fit.py`, and `multi/features/imaging_and_interferometer/modeling.py`). All pass `fit=fit` only — none pass `residuals_symmetric_cmap` — so all 11 could be switched to the new name and would gain critical-curve overlays for free.

Not done here: that is a visual change across 11 lens examples and deserves its own review, separate from making the function reachable. Filed against #667.

</details>

Generated by the PyAutoLabs agent workflow.
