### PR TITLE
fix: Optional[None] used as default value in tracer + max_separation

### DIFF
--- a/autolens/lens/tracer.py
+++ b/autolens/lens/tracer.py
@@ -247,7 +247,7 @@ class Tracer(ABC, ag.OperateImageGalaxies):
 
     @aa.decorators.to_grid
     def traced_grid_2d_list_from(
-        self, grid: aa.type.Grid2DLike, xp=np, plane_index_limit: int = Optional[None]
+        self, grid: aa.type.Grid2DLike, xp=np, plane_index_limit: Optional[int] = None
     ) -> List[aa.type.Grid2DLike]:
         """
         Returns a ray-traced grid of 2D Cartesian (y,x) coordinates which accounts for multi-plane ray-tracing.

--- a/autolens/lens/tracer_util.py
+++ b/autolens/lens/tracer_util.py
@@ -175,7 +175,7 @@ def traced_grid_2d_list_from(
     planes: List[List[ag.Galaxy]],
     grid: aa.type.Grid2DLike,
     cosmology: ag.cosmo.LensingCosmology = None,
-    plane_index_limit: int = Optional[None],
+    plane_index_limit: Optional[int] = None,
     xp=np,
 ):
     """

--- a/autolens/point/max_separation.py
+++ b/autolens/point/max_separation.py
@@ -24,7 +24,7 @@ class SourceMaxSeparation:
         data: aa.Grid2DIrregular,
         noise_map: Optional[aa.ArrayIrregular],
         tracer: Tracer,
-        plane_redshift: float = Optional[None],
+        plane_redshift: Optional[float] = None,
         xp=np,
     ):
         """


### PR DESCRIPTION
## Summary

Fixes three sites that used the typing construct `Optional[None]` as a *default value* (it evaluates to `NoneType`, a truthy class object that passes `is not None` guards):

- `autolens/lens/tracer.py` — `traced_grid_2d_list_from(..., plane_index_limit: Optional[int] = None)`
- `autolens/lens/tracer_util.py` — same signature fix in the module-level function
- `autolens/point/max_separation.py` — `SourceMaxSeparation(..., plane_redshift: Optional[float] = None)`

Behavior is preserved at all three sites (verified by reading the callees): the tracer's early-exit guard previously ran on every default call but compared `plane_index == NoneType` (always False), and `SourceMaxSeparation`'s default only worked because `np.isclose(NoneType, z)` raises the same `TypeError` that `np.isclose(None, z)` does, hitting the existing `except TypeError` fallback to `plane_index = -1`.

Sweep of PyAutoGalaxy, PyAutoArray and PyAutoFit found no further sites. Found while re-syncing the pedagogical code copies in autolens_workspace#413 (issue #674).

## Test Plan
- [x] `python -m pytest test_autolens/lens/ test_autolens/point/` — 200 passed
- [ ] Full CI matrix (3.12 + 3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)