### PR TITLE
fix: floor intra-family deps so autolens[optional] imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,13 @@ classifiers = [
 ]
 keywords = ["cli"]
 dependencies = [
-    "autogalaxy",
+    # Floor, not a pin. Without one, pip backtracking the extras chain
+    # (autolens[jax] -> autogalaxy[jax] -> autofit[jax] -> autonerves[jax]) may
+    # walk the release history to 2022: "version X does not provide the extra
+    # 'jax'" is a pip *warning*, not an error, so a pre-extras release is a
+    # legal solution. That is how `autolens[optional]` came to install autofit
+    # 2026.4.30.582 and fail on `af.Latent` (#687).
+    "autogalaxy>=2026.7.29.2",
     "nautilus-sampler==1.0.5"
 ]
 
@@ -43,7 +49,7 @@ local_scheme = "no-local-version"
 
 
 [project.optional-dependencies]
-jax = ["autogalaxy[jax]"]
+jax = ["autogalaxy[jax]>=2026.7.29.2"]
 coolest = ["coolest"]
 optional = [
     "autolens[jax]",


### PR DESCRIPTION
## Summary

`pip install "autolens[optional]"` can resolve an **April** `autofit`
(`2026.4.30.582`) alongside a current autoarray/autogalaxy/autonerves, so the
install succeeds and then `import autolens` dies with
`AttributeError: module 'autofit' has no attribute 'Latent'`. That is the
PyAutoHeart `verify_install` **Check D** failure holding release readiness RED
(run 30788224561, job 91606144514).

Every intra-family dependency across the libraries is a **bare package name with
no version floor**. When pip backtracks through the
`[optional] → [jax] → autofit[jax] → autonerves[jax]` extras chain it may walk
the release history back to 2022 — and pip treats
*"version X does not provide the extra 'jax'"* as a **warning, not an error**,
so a pre-extras release is a legal solution and pip settles there.

It is invisible on python3.12 (which happens to stop at a release that still has
`af.Latent`) and fatal on python3.13, which is what the release job's `python3`
resolves to.

This PR adds `>=2026.7.29.2` floors to the **cross-package** intra-family
dependencies. `2026.7.29.2` is live on PyPI, is not yanked, and is the oldest
release still carrying `af.Latent`. These are floors, not exact pins —
consistent with the floors-not-pins release design.

**Self-referential** extras (e.g. `autolens[jax]` inside `autolens[optional]`)
are deliberately left unfloored: a self-reference is already version-locked, and
a floor there would make a local `1.0.dev0` wheel build unsatisfiable.

### What this repo changes

- `dependencies`: `autogalaxy` → `autogalaxy>=2026.7.29.2`
- `[jax]`: `autogalaxy[jax]` → `autogalaxy[jax]>=2026.7.29.2`
- `[optional]`'s `autolens[jax]` self-reference left bare, deliberately.

This is the repo whose `autolens[optional]` extra surfaces the bug.

## API Changes

None. No Python symbol is added, removed or renamed — this is packaging
metadata only. The installed dependency *versions* change: pip can no longer
resolve a PyAuto sibling below `2026.7.29.2`, which is the point.

## Test Plan
- [x] Built the whole family into wheels from this branch and installed
      `autolens[optional]==2026.8.3.1.dev69801` on **python3.13** in a clean venv
      (`PYTHONPATH` unset), against TestPyPI + PyPI:
      - siblings with **today's** bare metadata → `autofit 2026.4.30.582`,
        `import autolens` raises `AttributeError: module 'autofit' has no attribute 'Latent'`
      - siblings with **this branch's** floored metadata → `autofit 2026.8.4.1`,
        `import autolens` OK
      Identical inputs; only the dependency metadata differs, so the floors are
      shown to work transitively (from sibling metadata, not just as top-level pins).
- [x] `tomllib` parses every edited `pyproject.toml`; built wheel `METADATA`
      carries the intended `Requires-Dist` floors.
- [x] `pyauto-heart verify_install D --testpypi --version 2026.8.3.1.dev69801` → PASS.

> Note: this is a family-wide fix — the floors only take effect once **all**
> the libraries are republished carrying them. The RED `verify_install` leg does
> not clear until a release rehearsal republishes to TestPyPI and Check D
> re-runs against those wheels.

Refs PyAutoLabs/PyAutoLens#687.

Generated by the PyAutoLabs agent workflow.
