### PR TITLE
Final HowToLens layout sweep in overview docs

### DIFF
--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -86,7 +86,7 @@ already be familiar and the statistical techniques used for fitting and modeling
 For those less familiar with these concepts (e.g. undergraduate students, new PhD students or interested members of the
 public), things may have been less clear and a slower more detailed explanation of each concept would be beneficial.
 
-The **HowToLens** Jupyter Notebook lectures provide exactly this. They are a 3+ chapter guide which thoroughly
+The **HowToLens** Jupyter Notebook lectures provide exactly this. They are a four-chapter guide which thoroughly
 take you through the core concepts of strong lensing, teach you the principles of the statistical techniques
 used in modeling and ultimately will allow you to undertake scientific research like a professional astronomer.
 

--- a/docs/overview/overview_3_features.md
+++ b/docs/overview/overview_3_features.md
@@ -44,7 +44,7 @@ galaxy:
 A complete overview of pixelized source reconstructions can be found
 at `notebooks/overview/overview_5_pixelizations.ipynb`.
 
-Chapter 4 of lectures describes pixelizations in detail and teaches users how they can be used to
+Chapter 3 of the **HowToLens** lectures describes pixelizations in detail and teaches users how they can be used to
 perform lens modeling.
 
 ## Point Sources


### PR DESCRIPTION
## Summary

Follow-up to PyAutoLabs/PyAutoLens#690 (merged): a whole-docs-tree sweep found two remaining stale references outside `docs/howtolens/`:

- `docs/overview/overview_3_features.md` — pixelizations lecture pointer chapter 4 → chapter 3.
- `docs/overview/overview_2_new_user_guide.md` — "3+ chapter guide" → four-chapter guide.

Docs-only; no library code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxKfSZisjnEn91LRGkN4SU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxKfSZisjnEn91LRGkN4SU)_