### PR TITLE
ci: allow manual Tests runs on main via workflow_dispatch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,18 @@ name: Tests
 # (Heart's ws_ci gate reads main-HEAD conclusions). Superseded runs are
 # cancelled on PR refs only — a cancelled main run would read as red CI
 # (cancelled is in Heart's FAILURE_CONCLUSIONS).
+#
+# `workflow_dispatch` exists so a main-HEAD run can be re-requested on demand.
+# On 2026-08-06 a GitHub Actions outage dropped the push triggers for several
+# main merges, leaving main-HEAD with no Tests conclusion at all — which reads
+# to Heart's ws_ci gate as missing evidence and blocks a release. Without a
+# manual trigger the only recovery was an empty commit to main, since re-running
+# an existing run re-tests its own (older) sha.
 on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: main-${{ github.ref }}


### PR DESCRIPTION
## What

Adds `workflow_dispatch:` to the `Tests` workflow (`.github/workflows/main.yml`), so a run against `main` HEAD can be re-requested on demand. One file, +8 lines (6 of them an explanatory comment).

No change to what is tested, or to when CI runs automatically — `push` to `main` and `pull_request` triggers are untouched.

## Why

The GitHub Actions outage on 2026-08-06 dropped the `push` triggers for several merges to `main`. The result is that `main` HEAD (`0c8c195`) carries **no `Tests` conclusion at all**; the last green main run is `490aad7`.

| commit | on main | Tests run |
|---|---|---|
| `0c8c195` (merge #692) | tip | none |
| `103ba06` | ✓ | none |
| `5c7e377` (merge #691) | ✓ | none |
| `805af3b` | ✓ | none |
| `490aad7` | ✓ | ✅ success |

That span is not docs-only — it adds Yang+2024 SIDM profile support to substructure halo batching (`autolens/lens/substructure_util.py`, +21), a new 142-line prior config, and 51 lines of new tests.

Heart's `ws_ci` gate reads main-HEAD conclusions, so missing evidence blocks a release exactly as a red run would.

Recovery was awkward because neither existing lever works:

- re-running an existing run re-tests **that run's own (older) sha**, not the current tip;
- the only remaining trigger was pushing an empty commit to `main`.

`workflow_dispatch` gives a direct way to re-request a main-HEAD run after any dropped-trigger event.

## Note

This PR's own `pull_request` run also exercises `main`'s current content, which supplies the missing evidence for the untested span above.

Sibling PR: PyAutoLabs/PyAutoGalaxy#560 (same change, same cause).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhmtTYYG4BianpWFSffZKN)_