### PR TITLE
docs: document spectral-line datacube modeling in the feature overview

### DIFF
--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -52,6 +52,7 @@ interested in:
 
 - **CDD Imaging**: For image data from telescopes like Hubble and James Webb, go to [imaging/start_here.ipynb](https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/imaging/start_here.ipynb).
 - **Interferometer**: For radio / sub-mm interferometer from instruments like ALMA, go to [interferometer/start_here.ipynb](https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/interferometer/start_here.ipynb).
+- **Data Cubes**: For spectral-line data cubes (e.g. ALMA CO cubes), where many frequency channels are fitted simultaneously with a shared lens model, go to [interferometer/features/datacube/start_here.ipynb](https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/interferometer/features/datacube/start_here.ipynb).
 - **Point Sources**: For strongly lensed point sources (e.g. lensed quasars, supernovae), go to [point_source/start_here.ipynb](https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/point_source/start_here.ipynb).
 
 ## Google Colab

--- a/docs/overview/overview_3_features.md
+++ b/docs/overview/overview_3_features.md
@@ -13,6 +13,8 @@ links to the relevant workspace examples.
 
 **Interferometry**: Modeling of interferometer data (e.g. ALMA, LOFAR) directly in the uv-plane.
 
+**Data Cubes**: Modeling spectral-line data cubes (e.g. ALMA CO cubes), fitting every channel simultaneously with a shared lens model.
+
 **Multi Gaussian Expansion (MGE)**: Decomposing the lens galaxy into hundreds of Gaussians, for a clean lens subtraction.
 
 **Groups**: Modeling group-scale strong lenses with multiple lens galaxies and multiple source galaxies.
@@ -102,6 +104,22 @@ such as correlated noise. This uses the non-uniform fast fourier transform algor
 \[PyNUFFT\](<https://github.com/jyhmiinlin/pynufft>) to efficiently map the galaxy model images to the uv-plane.
 
 Checkout the `autolens_workspace/*/interferometer` package to get started.
+
+## Data Cubes
+
+Spectral-line observations produce a data cube: the same field observed in many adjacent frequency channels, so that
+the source's emission-line kinematics can be studied alongside the lens model.
+
+A cube is modeled as a list of `Interferometer` datasets, one per channel, combined into a single fit with
+`af.FactorGraphModel`. Every channel shares one lens mass model, while each channel reconstructs its own source, so
+the lens is constrained by the whole cube simultaneously rather than channel by channel. There is no separate cube
+dataset type to learn — the existing `Interferometer` and `AnalysisInterferometer` objects are reused throughout.
+
+Channel-invariant quantities (the lensing operator's curvature matrix) are computed once and shared across channels
+rather than rebuilt per channel, which is what makes fitting a many-channel cube tractable.
+
+Checkout the `autolens_workspace/*/interferometer/features/datacube` package to get started, which includes a
+`data_preparation` example covering the conversion from a CASA-style 4D FITS cube to the inputs the fit expects.
 
 ## Multi Gaussian Expansion (MGE)
 


### PR DESCRIPTION
## Summary

Datacube modeling shipped in May 2026 (`autolens_workspace#120`) but was never documented. A user reading the feature overview or the "What Dataset Type?" routing had no way to learn that spectral-line cubes are supported — which is how the original requester's thread ([PyAutoMind#18](https://github.com/PyAutoLabs/PyAutoMind/issues/18)) ended up sitting open for three months after the feature it asked for had already landed.

## Changes

**`docs/overview/overview_3_features.md`**
- New **Data Cubes** one-line entry in the feature summary list at the top.
- New `## Data Cubes` section covering the design: a cube is a list of `Interferometer` datasets combined with `af.FactorGraphModel`, one shared lens mass model, a per-channel source, and channel-invariant curvature computed once rather than rebuilt per channel.

**`docs/overview/overview_2_new_user_guide.md`**
- New **Data Cubes** entry in the "What Dataset Type?" routing list, linking to `interferometer/features/datacube/start_here.ipynb`.

## Notes

- **No API change.** `docs/api/data.rst` is deliberately untouched — there is no cube dataset type to document, which is itself the architectural point the new section makes.
- Notebook link target verified present on `autolens_workspace@main`.
- Pairs with PyAutoLabs/autolens_workspace#482, which surfaces the same feature in the workspace READMEs.
