### PR TITLE
fix: sum PositionsLH penalties instead of doubling the last entry

### DIFF
--- a/autolens/analysis/analysis/lens.py
+++ b/autolens/analysis/analysis/lens.py
@@ -157,8 +157,8 @@ class AnalysisLens:
 
         Returns
         -------
-        The penalty value of the positions log likelihood, if the positions do not trace close in the source plane,
-        else a None is returned to indicate there is no penalty.
+        The summed penalty value of every positions log likelihood, if positions do not trace close in the
+        source plane, else an array-valued 0.0 to indicate there is no penalty.
         """
         log_likelihood_penalty = self._xp.array(0.0)
 
@@ -169,12 +169,11 @@ class AnalysisLens:
                 if positions_likelihood is not None:
 
                     log_likelihood_penalty = (
-                        positions_likelihood.log_likelihood_penalty_from(
+                        log_likelihood_penalty
+                        + positions_likelihood.log_likelihood_penalty_from(
                             instance=instance, analysis=self, xp=self._xp
                         )
                     )
-
-                    log_likelihood_penalty += log_likelihood_penalty
 
             return log_likelihood_penalty
 

--- a/test_autolens/imaging/model/test_analysis_imaging.py
+++ b/test_autolens/imaging/model/test_analysis_imaging.py
@@ -98,7 +98,13 @@ def test__positions__likelihood_overwrites__changes_likelihood(masked_imaging_7x
     )
     analysis_log_likelihood = analysis.log_likelihood_function(instance=instance)
 
-    assert analysis_log_likelihood == pytest.approx(-44097289521.734665, 1.0e-4)
+    analysis_log_likelihood_penalty = analysis.log_likelihood_penalty_from(instance=instance)
+    positions_log_likelihood_penalty = positions_likelihood.log_likelihood_penalty_from(
+        instance=instance, analysis=analysis
+    )
+
+    assert analysis_log_likelihood_penalty == pytest.approx(positions_log_likelihood_penalty, 1.0e-8)
+    assert analysis_log_likelihood == pytest.approx(-22048644768.175858, 1.0e-4)
 
 
 def test__positions__likelihood_overwrites__changes_likelihood__double_source_plane_example(masked_imaging_7x7):
@@ -123,7 +129,22 @@ def test__positions__likelihood_overwrites__changes_likelihood__double_source_pl
     )
     analysis_log_likelihood = analysis.log_likelihood_function(instance=instance)
 
-    assert analysis_log_likelihood == pytest.approx(-44097289521.734665, 1.0e-4)
+    analysis_log_likelihood_penalty = analysis.log_likelihood_penalty_from(instance=instance)
+    positions_log_likelihood_penalty_0 = positions_likelihood_0.log_likelihood_penalty_from(
+        instance=instance, analysis=analysis
+    )
+    positions_log_likelihood_penalty_1 = positions_likelihood_1.log_likelihood_penalty_from(
+        instance=instance, analysis=analysis
+    )
+
+    # The analysis penalty is the SUM of every entry in `positions_likelihood_list` -- a regression
+    # test against the historical bug where the loop returned 2x the last entry's penalty and
+    # discarded all earlier entries.
+    assert analysis_log_likelihood_penalty == pytest.approx(
+        positions_log_likelihood_penalty_0 + positions_log_likelihood_penalty_1, 1.0e-8
+    )
+    assert positions_log_likelihood_penalty_0 != pytest.approx(positions_log_likelihood_penalty_1, 1.0e-4)
+    assert analysis_log_likelihood == pytest.approx(-44140499627.74848, 1.0e-4)
 
 
 

--- a/test_autolens/interferometer/model/test_analysis_interferometer.py
+++ b/test_autolens/interferometer/model/test_analysis_interferometer.py
@@ -81,7 +81,7 @@ def test__positions__likelihood_overwrite__changes_likelihood(
     )
     analysis_log_likelihood = analysis.log_likelihood_function(instance=instance)
 
-    assert analysis_log_likelihood == pytest.approx(-44097289569.2342, 1.0e-4)
+    assert analysis_log_likelihood == pytest.approx(-22048644815.84869, 1.0e-4)
 
 
 def _pixelization_model():


### PR DESCRIPTION
## Overview

Fixes #699. `AnalysisLens.log_likelihood_penalty_from` overwrote its accumulator with each entry's penalty and then added the variable to itself (`lens.py:171-177`), so the analysis subtracted **2x the LAST** `PositionsLH` penalty and silently discarded every earlier entry in `positions_likelihood_list`.

## Change

- The penalty is now the **sum over all entries**, matching the documented `1e8 * (max_separation - threshold)` contract (`autolens/analysis/analysis/lens.py`).
- Docstring aligned to the actual behaviour (array-valued 0.0 when no penalty — kept for the JAX path; the loop change is a plain `x = x + y`, trivially `xp`-safe under `jnp`).

## Science impact

- Inside the threshold the penalty is exactly 0 either way — converged posteriors and all positions-free results unchanged.
- Outside the threshold the fence slope halves from the undocumented 2e8/arcsec to the documented 1e8/arcsec: likelihood values in penalized regions shift (release-notes item).
- Multi-plane / double-source-plane penalty stacking is corrected: previously only the last plane's penalty counted.

## Tests

- The imaging double-plane test asserted the SAME value (-44097289521.7) for one and for two penalties — the 2x-last signature. Repinned: single-penalty `-22048644768.18` (exactly half), double-plane `-44140499627.75` (the true sum, distinct from the old value).
- Interferometer positions test repinned the same way (`-44097289569.2` → `-22048644815.85`).
- New regression assertions: the analysis penalty equals the sum of each entry's own `log_likelihood_penalty_from`, the two per-plane penalties genuinely differ, and the single-entry case equals the entry's value exactly (no 2x).
- `python -m pytest test_autolens/` — **538 passed, 0 failed**.

## Context

CP-1 of the inference-methods programme (planning pass 2026-08-17): every PositionsLH benchmark depends on the penalty matching its documented form. Pending-release: merge is a human act.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
