### PR TITLE
docs: fix stale chaining notebook link in model cookbook

### DIFF
--- a/docs/general/model_cookbook.md
+++ b/docs/general/model_cookbook.md
@@ -427,7 +427,7 @@ When performing non-linear search chaining, the inferred model of one phase can 
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/imaging/advanced/chaining/start_here.ipynb>
+<https://github.com/PyAutoLabs/autolens_workspace/blob/main/notebooks/guides/modeling/chaining.ipynb>
 
 ## Across Datasets (Advanced)
 


### PR DESCRIPTION
Runs the Mind prompt `draft/docs/autolens/cookbook_stale_chaining_link.md` (filed during the three-regime restructure close-out, PyAutoMind#238).

The "Model Linking (Advanced)" section of `docs/general/model_cookbook.md` linked to `notebooks/imaging/advanced/chaining/start_here.ipynb`, which 404s — the chaining content moved to `notebooks/guides/modeling/chaining.ipynb` in the workspace reorganisation. One-line fix pointing at the current path (verified to resolve on autolens_workspace `main`).

Sweep per the prompt: all nine autolens_workspace links in the cookbook now return 200, and no other file under `docs/` references the dead `advanced/chaining` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHfvdagPTJDDEsTHcFnatQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHfvdagPTJDDEsTHcFnatQ)_