### PR TITLE
feat: JAX default install, [jax] alias + install docs (#702)

### DIFF
--- a/docs/installation/conda.md
+++ b/docs/installation/conda.md
@@ -8,19 +8,20 @@
 
 This acceleration is achieved through \[**JAX**\](<https://docs.jax.dev/en/latest/notebooks/thinking_in_jax.html>), which provides GPU and TPU support.
 
-**JAX is not installed by default.** To install **PyAutoLens** with JAX, use the `jax` extra:
+**JAX is installed by default** — a plain `pip install autolens` includes it (the older
+`pip install autolens[jax]` command still works and installs the same thing).
 
-```bash
-pip install autolens[jax] --no-cache-dir
-```
-
-A plain `pip install autolens` gives a fully working install that runs on NumPy, but without any of the JAX
-acceleration described above.
-
-The `[jax]` extra installs **CPU-only** JAX. To ensure GPU acceleration, it is recommended that you install JAX with
+The default install includes **CPU-only** JAX. To ensure GPU acceleration, it is recommended that you install JAX with
 GPU support **before** installing **PyAutoLens**, by following the official \[JAX installation guide\](<https://jax.readthedocs.io/en/latest/installation.html>).
 
 If you install **PyAutoLens** without a proper GPU setup, a warning will be displayed.
+
+:::{note}
+**Intel Macs**: JAX no longer publishes wheels for Intel (x86_64) macOS, so on these machines
+`pip install autolens` automatically installs without JAX and runs on the slower NumPy path — a
+warning is printed at import to make this clear. Every other supported platform (Windows, Linux,
+Apple-silicon Macs) gets JAX by default.
+:::
 
 ## Install
 
@@ -57,11 +58,13 @@ The latest version of **PyAutoLens** is installed via pip as follows (the comman
 caching issues impacting the installation):
 
 ```bash
-pip install autolens[jax] --no-cache-dir
+pip install autolens --no-cache-dir
 ```
 
-The `[jax]` extra is recommended, as it enables the JAX acceleration described above. To install without JAX,
-use `pip install autolens --no-cache-dir` instead.
+This includes JAX by default, enabling the acceleration described above. If you need an install without
+JAX on a platform where JAX wheels exist (e.g. a restricted environment), install normally and then run
+`pip uninstall jax jaxlib` — **PyAutoLens** detects the absence at import and falls back to the fully
+supported (but much slower) NumPy path.
 
 If pip prints warnings about dependency version conflicts, these can usually be ignored — the instructions below
 will identify clearly if the installation is a success.

--- a/docs/installation/pip.md
+++ b/docs/installation/pip.md
@@ -14,19 +14,20 @@ distribution" error. Upgrade Python to 3.12+ before installing.
 
 This acceleration is achieved through \[**JAX**\](<https://docs.jax.dev/en/latest/notebooks/thinking_in_jax.html>), which provides GPU and TPU support.
 
-**JAX is not installed by default.** To install **PyAutoLens** with JAX, use the `jax` extra:
+**JAX is installed by default** — a plain `pip install autolens` includes it (the older
+`pip install autolens[jax]` command still works and installs the same thing).
 
-```bash
-pip install autolens[jax]
-```
-
-A plain `pip install autolens` gives a fully working install that runs on NumPy, but without any of the JAX
-acceleration described above.
-
-The `[jax]` extra installs **CPU-only** JAX. To ensure GPU acceleration, it is recommended that you install JAX with
+The default install includes **CPU-only** JAX. To ensure GPU acceleration, it is recommended that you install JAX with
 GPU support **before** installing **PyAutoLens**, by following the official \[JAX installation guide\](<https://jax.readthedocs.io/en/latest/installation.html>).
 
 If you install **PyAutoLens** without a proper GPU setup, a warning will be displayed.
+
+:::{note}
+**Intel Macs**: JAX no longer publishes wheels for Intel (x86_64) macOS, so on these machines
+`pip install autolens` automatically installs without JAX and runs on the slower NumPy path — a
+warning is printed at import to make this clear. Every other supported platform (Windows, Linux,
+Apple-silicon Macs) gets JAX by default.
+:::
 
 ## Install
 
@@ -40,19 +41,21 @@ We upgrade pip to ensure certain libraries install:
 pip install --upgrade pip
 ```
 
-The latest version of **PyAutoLens** is installed via pip as follows (specifying the version as shown below ensures
-the installation has clean dependencies):
-
-```bash
-pip install autolens[jax]
-```
-
-The `[jax]` extra is recommended, as it enables the JAX acceleration described above. To install without JAX,
-omit the extra:
+The latest version of **PyAutoLens** is installed via pip as follows:
 
 ```bash
 pip install autolens
 ```
+
+This includes JAX by default, enabling the acceleration described above. If you need an install without
+JAX on a platform where JAX wheels exist (e.g. a restricted environment), install normally and then remove it:
+
+```bash
+pip uninstall jax jaxlib
+```
+
+**PyAutoLens** detects the absence at import and falls back to the fully supported (but much slower)
+NumPy path.
 
 If pip prints warnings about dependency version conflicts, these can usually be ignored — the instructions below
 will identify clearly if the installation is a success.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,10 @@ classifiers = [
 ]
 keywords = ["cli"]
 dependencies = [
-    # Floor, not a pin. Without one, pip backtracking the extras chain
-    # (autolens[jax] -> autogalaxy[jax] -> autofit[jax] -> autonerves[jax]) may
-    # walk the release history to 2022: "version X does not provide the extra
-    # 'jax'" is a pip *warning*, not an error, so a pre-extras release is a
-    # legal solution. That is how `autolens[optional]` came to install autofit
-    # 2026.4.30.582 and fail on `af.Latent` (#687).
+    # Floor, not a pin (#687 — a floorless backtrack once installed autofit
+    # 2026.4.30.582 and failed on `af.Latent`). Bump to the first release with
+    # JAX in the family's base dependencies once it exists (#702), so
+    # backtracking cannot pair this autolens with a jax-optional chain.
     "autogalaxy>=2026.7.29.2",
     "nautilus-sampler==1.0.5"
 ]
@@ -49,7 +47,9 @@ local_scheme = "no-local-version"
 
 
 [project.optional-dependencies]
-jax = ["autogalaxy[jax]>=2026.7.29.2"]
+# JAX moved into the base dependencies (#702). Kept as a declared no-op so
+# `pip install autolens[jax]` keeps resolving (#687).
+jax = []
 coolest = ["coolest"]
 optional = [
     "autolens[jax]",

--- a/test_autolens/potential_correction/test_iterative_interferometer.py
+++ b/test_autolens/potential_correction/test_iterative_interferometer.py
@@ -61,6 +61,7 @@ def test__solve_joint_optimization__finite_state_and_decreasing_cost(
     assert np.isfinite(dpsi_opt).all()
 
 
+@requires_jax
 def test__solve_joint_optimization__identity_damping_finite(interferometer_7):
     dataset = interferometer_7.apply_sparse_operator()
     fit = iter_fit_from(dataset, damping="identity", max_consecutive_rejections=3)


### PR DESCRIPTION
## Summary
Closes the packaging half of #702: JAX is now a default dependency of the stack. autolens receives jax, optax and jax_zero_contour transitively through the autogalaxy → autofit → autonerves base-dependency chain (each promoted in its own repo's sibling PR), so the changes here are the `[jax]` extra becoming a declared no-op alias (#687), the floor comment recording the follow-up floor bump, and the install docs.

Docs (`docs/installation/pip.md`, `conda.md`): `pip install autolens` is now the JAX-enabled command; the `[jax]` form is documented as a still-working alias; Intel Macs (no jaxlib `macosx_x86_64` wheels ≥0.7) are documented as automatically falling back to the fully supported NumPy-only path, with a loud import-time warning.

## API Changes
None — packaging metadata and install docs only.
See full details below.

## Test Plan
- [x] pyproject parses; `[jax]` alias resolves
- [x] Clean-venv install of the promoted chain pulls jax 0.11.1 + jaxnnls automatically
- [ ] No-JAX CI leg (PyAutoHeart lib-tests.yml `unittest-nojax`) green once the Heart PR merges

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `pip install autolens` now installs JAX by default via the family chain (except Intel macOS, which falls back to NumPy-only with an import-time warning).

### Migration
- Before: `pip install autolens[jax]`
- After: `pip install autolens` (the `[jax]` form still works — no-op alias)

</details>

Sibling PRs: PyAutoNerves, PyAutoFit, PyAutoArray, PyAutoGalaxy (packaging), PyAutoHeart (no-JAX CI leg). Follow-up after the first promoted release: bump the intra-family floors to it.

Generated by the PyAutoLabs agent workflow.
