### PR TITLE
refactor: future-annotations headers for lazy aggregator imports

### DIFF
--- a/autolens/aggregator/fit_imaging.py
+++ b/autolens/aggregator/fit_imaging.py
@@ -14,6 +14,8 @@ Two public objects are provided:
   that exposes a generator of ``FitImaging`` objects, enabling memory-efficient iteration
   over large result sets.
 """
+
+from __future__ import annotations
 from typing import Optional, List
 
 import autofit as af

--- a/autolens/aggregator/fit_interferometer.py
+++ b/autolens/aggregator/fit_interferometer.py
@@ -15,6 +15,8 @@ Two public objects are provided:
   ``Aggregator`` that exposes a generator of ``FitInterferometer`` objects, enabling
   memory-efficient iteration over large result sets.
 """
+
+from __future__ import annotations
 from typing import Optional, List
 
 import autofit as af

--- a/autolens/aggregator/subhalo.py
+++ b/autolens/aggregator/subhalo.py
@@ -10,6 +10,8 @@ collates these per-cell results and exposes generators that yield ``FitImaging``
 for the best-fit model in each cell — both the "with subhalo" fit and (optionally) the
 "no subhalo" baseline — enabling the per-cell log-evidence difference map to be computed.
 """
+
+from __future__ import annotations
 from typing import Optional
 
 import autofit as af


### PR DESCRIPTION
## Summary
Part of the cross-repo import-time task (PyAutoFit#1505). Same one-line change as the PyAutoGalaxy PR: three aggregator modules evaluate `af.Aggregator` / `af.GridSearchAggregator` in def-time annotations, re-triggering the sqlalchemy/database import the task defers. `from __future__ import annotations` headers in `aggregator/fit_imaging.py`, `aggregator/fit_interferometer.py`, `aggregator/subhalo.py` make them lazy strings. Net cross-repo result: `import autolens` 4.07s → ~2.1s with jax, blackjax, optax, nufftax, IPython, sqlalchemy, numba and astropy all absent from the bare import tree.

## API Changes
None — internal changes only (annotation evaluation semantics in three modules).
See full details below.

## Test Plan
- [x] Full suite: 538 passed against the sibling branches
- [x] `python -X importtime -c "import autolens"` heavy-module grep: zero hits
- [x] autolens_workspace smoke 37/37; autolens_workspace_test 20/24 — identical to canonical `main` (the 4 jax_likelihood pin failures are pre-existing; control-tested, see PyAutoFit#1505)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- None — `from __future__ import annotations` added to three aggregator modules; annotations become lazy strings (PEP 563), no runtime introspection of them exists.

### Migration
- None required.

</details>

Generated by the PyAutoLabs agent workflow.
