### PR TITLE
docs: correct the install page — wrong failure mode, wrong cut release, wrong support range

### DIFF
--- a/docs/installation/overview.md
+++ b/docs/installation/overview.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-**PyAutoLens** requires Python 3.12 - 3.13 and supports the Linux, MacOS and Windows operating systems.
+**PyAutoLens** requires Python 3.12 or later and supports the Linux, MacOS and Windows operating systems.
 
 **PyAutoLens** can be installed via the Python distribution [Anaconda](https://www.anaconda.com/) or using
 [Pypi](https://pypi.org/) to `pip install autolens` into your Python distribution.

--- a/docs/installation/pip.md
+++ b/docs/installation/pip.md
@@ -3,9 +3,10 @@
 # Installation with pip
 
 :::{note}
-**PyAutoLens** requires **Python 3.12 or later**. If you are on Python
-3.9, 3.10, or 3.11, `pip install autolens` will fail with a "no matching
-distribution" error. Upgrade Python to 3.12+ before installing.
+**PyAutoLens** requires **Python 3.12 or later**. On Python 3.9, 3.10 or 3.11,
+`pip install autolens` stops with an error telling you to upgrade — it will not
+quietly install an older release instead. Upgrade Python to 3.12+ before
+installing.
 :::
 
 ## JAX & GPU
@@ -119,16 +120,26 @@ it is safe not to install them initially.
 
 ## Legacy Python versions
 
-We dropped support for Python 3.9, 3.10, and 3.11 in release `2026.4.5.3`
-(April 2026). Pre-`2026.4.5.3` releases on PyPI have been yanked, so they
-will not install via the standard `pip install autolens` command.
+We dropped support for Python 3.9, 3.10 and 3.11 in release `2026.7.29.2`
+(July 2026) — the first release published declaring `Requires-Python >=3.12`.
 
-If you have an existing project that requires a pre-`2026.4.5.3` version,
-you can still install it explicitly by pinning the version, e.g.:
+Raising that floor does not retract what is already published. Releases at or
+below `2026.7.29.1` were published declaring `>=3.9`, and PyPI metadata is
+immutable, so they remain valid candidates forever. Left alone, `pip install
+autolens` on an older Python did not fail — it walked back to `2026.7.29.1` and
+installed a months-old stack without JAX, reporting nothing.
+
+Release `2026.7.29.1.post1` exists to stop that. It contains no code, declares
+`Requires-Python <3.12`, and raises an error when pip tries to build it, so an
+unsupported Python gets an explanation instead of a stale install.
+
+If you need a historical release, pin it exactly — that still resolves on older
+Pythons:
 
 ```bash
 pip install autolens==2025.10.6.1
 ```
 
-Yanked releases remain available for explicit pins; only resolver-driven
-fallback is blocked.
+One gap remains: `pip install --only-binary=:all: autolens` skips source
+distributions entirely, so it steps past `2026.7.29.1.post1` and installs the
+old wheel silently. If you use that flag, pin the version you want.


### PR DESCRIPTION
Phase 2 of PyAutoLabs/PyAutoHands#238. The tombstone releases are live on PyPI (PyAutoHands [#240](https://github.com/PyAutoLabs/PyAutoHands/pull/240), [#242](https://github.com/PyAutoLabs/PyAutoHands/pull/242)); this makes the install page describe what actually happens.

## Three false claims, not one

**1. The failure mode.** The page said `pip install autolens` on 3.9/3.10/3.11 "will fail with a no matching distribution error". It did not. Verified on real venvs with pip 26.2.1, before the fix:

| Python | actual result |
|--------|---------------|
| 3.9 | silently installed the **2026.7.29.1** stack, exit 0 |
| 3.10 | same |
| 3.11 | same |
| 3.12 | 2026.8.17.1 (current) |

No JAX, no warning, months out of date. Worse than the documented hard failure, because nothing told the user which version they were running.

**2. The cut release.** "We dropped support ... in release `2026.4.5.3`" is the wrong release. That floor was reverted on 2026-04-30, and `2026.5.1.4` … `2026.7.29.1` all shipped `>=3.9` again. The real cut is **`2026.7.29.2`**.

**3. The yank.** "Pre-`2026.4.5.3` releases on PyPI have been yanked, so they will not install" — they were not. **396 of 421** `autolens` releases are live; the 25 yanked ones are a scattering from the autoconf-rename period. The section's entire premise was a yank that never happened, which is why the resolver fallback it claimed was blocked was in fact wide open.

## What it says now

The real cut release, why raising a floor does not retract a back catalogue, and the `2026.7.29.1.post1` tombstone that now refuses the install. It also states the one remaining gap rather than hiding it: `--only-binary=:all:` skips source distributions, steps past the tombstone, and installs the old wheel silently.

Pinned historical installs are unaffected and still resolve on old Pythons.

## API Changes

None. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
