### PR TITLE
feat: rectangular mesh split follow-up — docs + prior-config key fix

### DIFF
--- a/autolens/exc.py
+++ b/autolens/exc.py
@@ -32,7 +32,7 @@ class PixelizationException(af.exc.FitException):
     """
     Raises exceptions associated with the `inversion/pixelization` modules and `Pixelization` classes.
 
-    For example if a `RectangularAdaptDensity` mesh has dimensions below 3x3.
+    For example if a `RectangularRTUAdaptDensity` mesh has dimensions below 3x3.
 
     This exception overwrites `autoarray.exc.PixelizationException` in order to add a `FitException`. This means that
     if this exception is raised during a model-fit in the analysis class's `log_likelihood_function` that model

--- a/docs/api/pixelization.rst
+++ b/docs/api/pixelization.rst
@@ -46,7 +46,10 @@ Mesh [ag.mesh]
    :template: custom-class-template.rst
    :recursive:
 
-   RectangularAdaptDensity
+   RectangularBilinearAdaptDensity
+   RectangularBilinearAdaptImage
+   RectangularRTUAdaptDensity
+   RectangularRTUAdaptImage
    Delaunay
 
 Regularization [ag.reg]

--- a/test_autolens/config/priors/pixelizations.yaml
+++ b/test_autolens/config/priors/pixelizations.yaml
@@ -50,27 +50,6 @@ delaunay.DelaunayMagnification:
     width_modifier:
       type: Absolute
       value: 8.0
-rectangular.RectangularAdaptDensity:
-  shape_0:
-    limits:
-      lower: 3.0
-      upper: inf
-    lower_limit: 20.0
-    type: Uniform
-    upper_limit: 45.0
-    width_modifier:
-      type: Absolute
-      value: 8.0
-  shape_1:
-    limits:
-      lower: 3.0
-      upper: inf
-    lower_limit: 20.0
-    type: Uniform
-    upper_limit: 45.0
-    width_modifier:
-      type: Absolute
-      value: 8.0
 voronoi.VoronoiBrightnessImage:
   pixels:
     limits:
@@ -123,3 +102,25 @@ voronoi.VoronoiMagnification:
     width_modifier:
       type: Absolute
       value: 8.0
+rectangular_bilinear_adapt_density.RectangularBilinearAdaptDensity: &id001
+  shape_0:
+    limits:
+      lower: 3.0
+      upper: inf
+    lower_limit: 20.0
+    type: Uniform
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0
+  shape_1:
+    limits:
+      lower: 3.0
+      upper: inf
+    lower_limit: 20.0
+    type: Uniform
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0
+rectangular_rtu_adapt_density.RectangularRTUAdaptDensity: *id001


### PR DESCRIPTION
## Summary

Downstream follow-up to the PyAutoArray rectangular mesh split (PyAutoLabs/PyAutoArray#462, merged; task PyAutoLabs/PyAutoArray#461), sibling of PyAutoLabs/PyAutoGalaxy#579.

## API Changes

None — internal changes only (docs, docstrings, test config; no Python API change).

## Test Plan

- [x] Full test suite against merged PyAutoArray + PyAutoGalaxy mains: 532 passed, 1 skipped.

<details>
<summary>Changes</summary>

- `docs/api/pixelization.rst`: lists all four adaptive rectangular classes (`RectangularBilinearAdaptDensity/Image`, `RectangularRTUAdaptDensity/Image`).
- `autolens/exc.py`: docstring name update.
- `test_autolens/config/priors/pixelizations.yaml`: the stale `rectangular.RectangularAdaptDensity` module-prefixed key never resolved (autonerves `JSONPriorConfig` matches on the real module path via `endswith`); rekeyed to `rectangular_bilinear_adapt_density.RectangularBilinearAdaptDensity` / `rectangular_rtu_adapt_density.RectangularRTUAdaptDensity`, which do resolve.

</details>

Generated by the PyAutoLabs agent workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtMqU3JfmyJh8GvB7jT4Et)_