### PR TITLE
build: bump intra-family floors to >=2026.8.22.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     # 2026.4.30.582 and failed on `af.Latent`). Bump to the first release with
     # JAX in the family's base dependencies once it exists (#702), so
     # backtracking cannot pair this autolens with a jax-optional chain.
-    "autogalaxy>=2026.7.29.2",
+    "autogalaxy>=2026.8.22.1",
     "nautilus-sampler==1.0.5"
 ]
 


### PR DESCRIPTION
Release `2026.8.22.1` promoted all five libraries together (nightly run 50), so the committed source floor moves from the previous promoted set `2026.7.29.2` to the first version carrying the JAX-default dependency handshake, the fnnls JAX fix (PyAutoArray#463) and the rectangular mesh split. Step (1) of the `jax-default-dependency` follow-ups recorded in PyAutoMind `active.md`; sibling PRs bump PyAutoFit, PyAutoArray and PyAutoGalaxy.

One line: `autogalaxy>=2026.7.29.2` → `>=2026.8.22.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GsUfbCwPd4XC8kpsiUJp7

---
_Generated by [Claude Code](https://claude.ai/code/session_015GsUfbCwPd4XC8kpsiUJp7)_