### PR TITLE
Remove pynufft following its removal from PyAutoArray

### DIFF
--- a/autolens/__init__.py
+++ b/autolens/__init__.py
@@ -27,7 +27,6 @@ from autoarray.inversion.mesh.border_relocator import BorderRelocator
 from autoarray.operators.convolver import Convolver
 from autoarray.operators.transformer import TransformerDFT
 from autoarray.operators.transformer import TransformerNUFFT
-from autoarray.operators.transformer import TransformerNUFFTPyNUFFT
 from autoarray.structures.arrays.uniform_1d import Array1D
 from autoarray.structures.arrays.uniform_2d import Array2D
 from autoarray.structures.arrays.rgb import Array2DRGB

--- a/docs/installation/conda.md
+++ b/docs/installation/conda.md
@@ -114,10 +114,10 @@ successful numba install working, with more information provided [at this readth
 
 ## Optional
 
-For interferometer analysis there are two optional dependencies that must be installed via the commands:
+For interferometer analysis there is one optional dependency that must be installed via the command:
 
 ```bash
-pip install pynufft
+pip install nufftax
 ```
 
 **PyAutoLens** will run without these libraries and it is recommended that you only install them if you intend to

--- a/docs/installation/pip.md
+++ b/docs/installation/pip.md
@@ -106,10 +106,10 @@ successful numba install working, with more information provided [at this readth
 
 ## Optional
 
-For interferometer analysis there are two optional dependencies that must be installed via the commands:
+For interferometer analysis there is one optional dependency that must be installed via the command:
 
 ```bash
-pip install pynufft
+pip install nufftax
 ```
 
 **PyAutoLens** will run without these libraries and it is recommended that you only install them if you intend to

--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -69,7 +69,7 @@ pip install numba
 For unit tests to pass you will also need the following optional requirements:
 
 ```bash
-pip install pynufft
+pip install nufftax
 ```
 
 If you are using a `conda` environment, add the source repository as follows:

--- a/docs/overview/overview_3_features.md
+++ b/docs/overview/overview_3_features.md
@@ -101,7 +101,7 @@ Modeling of interferometer data from submillimeter (e.g. ALMA) and radio (e.g. L
 
 Visibilities data is fitted directly in the uv-plane, circumventing issues that arise when fitting a dirty image
 such as correlated noise. This uses the non-uniform fast fourier transform algorithm
-\[PyNUFFT\](<https://github.com/jyhmiinlin/pynufft>) to efficiently map the galaxy model images to the uv-plane.
+\[nufftax\](<https://github.com/GragasLab/nufftax>) to efficiently map the galaxy model images to the uv-plane.
 
 Checkout the `autolens_workspace/*/interferometer` package to get started.
 

--- a/files/citations.bib
+++ b/files/citations.bib
@@ -189,20 +189,6 @@ year = {2015}
   title = {`PyAutoLens`: Open-Source Strong Gravitational Lensing},
   journal = {J. Open Source Softw.}
 }
-@article{pynufft,
-abstract = {A Python non-uniform fast Fourier transform (PyNUFFT) package has been developed to accelerate multidimensional non-Cartesian image reconstruction on heterogeneous platforms. Since scientific computing with Python encompasses a mature and integrated environment, the time efficiency of the NUFFT algorithm has been a major obstacle to real-time non-Cartesian image reconstruction with Python. The current PyNUFFT software enables multi-dimensional NUFFT accelerated on a heterogeneous platform, which yields an efficient solution to many non-Cartesian imaging problems. The PyNUFFT also provides several solvers, including the conjugate gradient method, 1 total variation regularized ordinary least square (L1TV-OLS), and 1 total variation regularized least absolute deviation (L1TV-LAD). Metaprogramming libraries have been employed to accelerate PyNUFFT. The PyNUFFT package has been tested on multi-core central processing units (CPUs) and graphic processing units (GPUs), with acceleration factors of 6.3–9.5× on a 32-thread CPU platform and 5.4–13× on a GPU.},
-author = {Lin, Jyh Miin},
-doi = {10.3390/jimaging4030051},
-file = {:home/jammy/Documents/Papers/Software/jimaging-04-00051-v2.pdf:pdf},
-issn = {2313433X},
-journal = {Journal of Imaging},
-keywords = {Graphic processing unit (GPU),Heterogeneous system architecture (HSA),Magnetic resonance imaging (MRI),Multi-core system,Total variation (TV)},
-number = {3},
-pages = {1--22},
-title = {{Python non-uniform fast fourier transform (PyNUFFT): An accelerated non-cartesian MRI package on a heterogeneous platform (CPU/GPU)}},
-volume = {4},
-year = {2018}
-}
  @book{python,
  author = {Van Rossum, Guido and Drake, Fred L.},
  title = {Python 3 Reference Manual},

--- a/files/citations.md
+++ b/files/citations.md
@@ -29,7 +29,6 @@ This work uses the following software packages:
 - `PyAutoFit` https://github.com/PyAutoLabs/PyAutoFit [@pyautofit]
 - `PyAutoGalaxy` https://github.com/PyAutoLabs/PyAutoGalaxy [@Nightingale2018] [@pyautogalaxy]
 - `PyAutoLens` https://github.com/PyAutoLabs/PyAutoLens [@Nightingale2015] [@Nightingale2018] [@pyautolens]
-- `PyNUFFT` https://github.com/jyhmiinlin/pynufft [@pynufft]
 - `Python` https://www.python.org/ [@python]
 - `scikit-image` https://github.com/scikit-image/scikit-image [@scikit-image]
 - `scikit-learn` https://github.com/scikit-learn/scikit-learn [@scikit-learn]

--- a/files/citations.tex
+++ b/files/citations.tex
@@ -95,10 +95,6 @@ This work uses the following software packages:
 \citep{Nightingale2015, Nightingale2018, pyautolens}
 
 \item
-\href{https://github.com/jyhmiinlin/pynufft}{\texttt{PyNUFFT}}
-\citep{pynufft}
-
-\item
 \href{https://www.python.org/}{\texttt{Python}}
 \citep{python}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ optional = [
     "autolens[jax]",
     "coolest",
     "numba",
-    "pynufft",
     "zeus-mcmc==2.5.4",
     "getdist==1.4"
 ]


### PR DESCRIPTION
## Summary

Companion to PyAutoLabs/PyAutoArray#475, which removes `TransformerNUFFTPyNUFFT` and the `pynufft` dependency.

Drops the `TransformerNUFFTPyNUFFT` re-export from `autolens/__init__.py:30` — it would raise `ImportError` at import once PyAutoArray's removal lands — and removes `pynufft` from the `optional` extra.

Also updates the live documentation and citation surface, which still described PyNUFFT as the interferometer NUFFT backend. The installation pages actively instructed users to `pip install pynufft`; they now point at `nufftax`, and the feature overview names the backend actually in use. `nufftax` was already cited in `files/citations.{md,tex,bib}`, so the PyNUFFT entries are simply dropped rather than replaced.

`paper/` is deliberately untouched — those are published JOSS records of what the software used at time of publication, not live documentation.

**Merge order:** merge PyAutoGalaxy#583 first, then this, then PyAutoArray#475 last. Dropping a re-export is safe against an autoarray that still has the class, so main is never red.

## API Changes

**Breaking:** `autolens.TransformerNUFFTPyNUFFT` is no longer re-exported (the class itself is removed upstream in PyAutoArray#475). Migration is `autolens.TransformerNUFFT`, or `autolens.TransformerDFT` where JAX is unavailable. `pynufft` is no longer an optional dependency.

See full details below.

## Test Plan

- [x] `pytest test_autolens` — **532 passed, 1 skipped** against PyAutoArray's and PyAutoGalaxy's `claude/remove-pynufft-6uwt2z` branches (Python 3.13)
- [x] `import autolens` succeeds; `hasattr(al, "TransformerNUFFTPyNUFFT")` is `False`
- [x] No `pynufft` references remain outside `paper/`

<details>
<summary>Full API Changes (for automation &amp; release notes)</summary>

### Removed
- `autolens.TransformerNUFFTPyNUFFT` — re-export of the class removed in PyAutoArray#475; replaced by `autolens.TransformerNUFFT`
- `pynufft` from `[project.optional-dependencies] optional`

### Changed Behaviour
- None in library code. Documentation and citation changes only, beyond the dropped re-export.

### Migration
- Before: `transformer = al.TransformerNUFFTPyNUFFT(uv_wavelengths=uv, real_space_mask=mask)`
- After: `transformer = al.TransformerNUFFT(uv_wavelengths=uv, real_space_mask=mask)`
- Without JAX (e.g. Intel macOS): `transformer = al.TransformerDFT(uv_wavelengths=uv, real_space_mask=mask)`

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6pH5eMAcAwjbfGUmCnwZF)_