### PR TITLE
fix: save_results survives a rejected max-likelihood sample (PyAutoFit#1535)

### DIFF
--- a/autolens/analysis/analysis/dataset.py
+++ b/autolens/analysis/analysis/dataset.py
@@ -189,5 +189,12 @@ class AnalysisDataset(AgAnalysisDataset, AnalysisLens):
                 obj=result.max_log_likelihood_tracer,
                 file_path=paths._files_path / "tracer.json",
             )
-        except AttributeError:
-            pass
+        except (AttributeError, af.exc.SamplesException, af.exc.FitException) as e:
+            # Building the tracer requires materializing the maximum log likelihood sample as a model
+            # instance, which the model may reject (e.g. `ell_comps` outside the unit disk). Writing an
+            # extra output file must never kill a completed fit before `paths.completed()` is called
+            # (PyAutoFit #1535), so the failure is logged and the fit finishes without `tracer.json`.
+            logger.warning(
+                f"The maximum log likelihood tracer could not be written to tracer.json, "
+                f"the model-fit is otherwise unaffected:\n{e}"
+            )

--- a/test_autolens/analysis/analysis/test_analysis_dataset.py
+++ b/test_autolens/analysis/analysis/test_analysis_dataset.py
@@ -118,3 +118,41 @@ def test__save_attributes__dataset_fits_output_for_aggregator(analysis_imaging_7
     assert ext_names[:4] == ["MASK", "DATA", "NOISE_MAP", "PSF"]
 
     os.remove(dataset_fits_path)
+
+
+class _RaisingTracerResult:
+    """
+    Result double whose tracer cannot be built, because materializing the maximum log
+    likelihood sample as a model instance fails.
+    """
+
+    def __init__(self, error):
+        self._error = error
+
+    @property
+    def max_log_likelihood_tracer(self):
+        raise self._error
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        AttributeError("no tracer on this result"),
+        af.exc.SamplesException("stored parameters cannot be reconstructed"),
+        af.exc.FitException("ell_comps must satisfy e0**2+e1**2 < 1"),
+    ],
+)
+def test__save_results__tracer_failure_never_kills_the_fit(analysis_imaging_7x7, error):
+    """
+    `save_results` runs after the search has finished but before `paths.completed()`, so a
+    failure writing the (optional) `tracer.json` must be logged and swallowed rather than
+    losing the run its `.completed` marker (PyAutoFit #1535).
+    """
+    paths = af.DirectoryPaths()
+
+    analysis_imaging_7x7.save_results(
+        paths=paths,
+        result=_RaisingTracerResult(error),
+    )
+
+    assert not (paths._files_path / "tracer.json").exists()


### PR DESCRIPTION
## Summary
`Analysis.save_results` writes the optional `tracer.json` from `result.max_log_likelihood_tracer` inside a `try` that caught only `AttributeError`. When the stored best point is rejected by the model, PyAutoFit raises `SamplesException` / `FitException` there, which escaped `start_resume_fit` before `paths.completed()` and killed six completed A100 fits (PyAutoLabs/autolens_profiling#182; root fix in PyAutoLabs/PyAutoFit#1535's PR). The catch is widened and logs a warning instead of silently passing.

Companion to the PyAutoFit PR; safe to merge independently.

## API Changes
None. `save_results` now logs a warning and continues when the maximum-likelihood tracer cannot be built, instead of raising.
See full details below.

## Test Plan
- [x] `pytest test_autolens -q` — 553 passed
- [x] New parametrized test: `save_results` swallows `AttributeError`, `af.exc.SamplesException`, `af.exc.FitException` from `max_log_likelihood_tracer`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- none

### Added
- none

### Migration
- none

</details>

Generated by the PyAutoLabs agent workflow.