### PR TITLE
feat: test prior config + docs for the AdaptPower regularization siblings

### DIFF
--- a/docs/api/pixelization.rst
+++ b/docs/api/pixelization.rst
@@ -66,6 +66,8 @@ Regularization [ag.reg]
    ConstantSplit
    Adapt
    AdaptSplit
+   AdaptPower
+   AdaptSplitPower
 
 Settings
 --------

--- a/test_autolens/config/priors/regularization.yaml
+++ b/test_autolens/config/priors/regularization.yaml
@@ -37,3 +37,143 @@ constant_zeorth.ConstantZeroth:
     width_modifier:
       type: Relative
       value: 0.5
+adapt_power.AdaptPower:
+  inner_coefficient:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  outer_coefficient:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  signal_scale:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+  power:
+    type: Constant
+    value: 1.0
+adapt_split_power.AdaptSplitPower:
+  inner_coefficient:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  outer_coefficient:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  signal_scale:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+  power:
+    type: Constant
+    value: 1.0
+adapt_split_zeroth_power.AdaptSplitZerothPower:
+  inner_coefficient:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  outer_coefficient:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  signal_scale:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+  zeroth_coefficient:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  zeroth_signal_scale:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+  power:
+    type: Constant
+    value: 1.0
+matern_adapt_power_kernel.MaternAdaptPowerKernel:
+  inner_coefficient:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  outer_coefficient:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  signal_scale:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+  scale:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+  nu:
+    lower_limit: 0.5
+    type: Uniform
+    upper_limit: 5.5
+  power:
+    type: Constant
+    value: 1.0

--- a/test_autolens/test_regularization_power.py
+++ b/test_autolens/test_regularization_power.py
@@ -1,0 +1,32 @@
+"""
+Model-composition gate for the ``*Power`` regularization siblings added in PyAutoArray, through the
+``al.reg`` namespace.
+
+Mirrors ``test_autogalaxy/test_regularization_power.py``; the prior entries this exercises live in
+``test_autolens/config/priors/regularization.yaml``.
+"""
+
+import autofit as af
+import autolens as al
+
+
+def test__power_classes_are_re_exported():
+    assert al.reg.AdaptPower is not al.reg.Adapt
+    assert al.reg.AdaptSplitPower is not al.reg.AdaptSplit
+    assert al.reg.AdaptSplitZerothPower is not al.reg.AdaptSplitZeroth
+    assert al.reg.MaternAdaptPowerKernel is not al.reg.MaternAdaptKernel
+
+
+def test__model_composition__power_is_a_constant_and_is_not_sampled():
+    model = af.Model(al.reg.AdaptSplitPower)
+
+    assert set(prior_tuple[0] for prior_tuple in model.prior_tuples) == {
+        "inner_coefficient",
+        "outer_coefficient",
+        "signal_scale",
+    }
+    assert model.instance_from_prior_medians().power == 1.0
+
+
+def test__model_identifier__differs_from_the_legacy_class():
+    assert af.Model(al.reg.AdaptSplit).identifier != af.Model(al.reg.AdaptSplitPower).identifier


### PR DESCRIPTION
## Summary

Test prior config, API docs and a composition test for the four `*Power` regularization siblings added in **PyAutoLabs/PyAutoArray#512** (`AdaptPower`, `AdaptSplitPower`, `AdaptSplitZerothPower`, `MaternAdaptPowerKernel`), through the `al.reg` namespace.

- `test_autolens/config/priors/regularization.yaml` gains the four entries, keyed `<module>.<Class>` as the file's existing entries are, with `power` fixed as a `Constant` prior. Verified live: the test config is consulted first, so these entries — not the packaged PyAutoGalaxy ones — are what the suite resolves.
- `docs/api/pixelization.rst` gains `AdaptPower` / `AdaptSplitPower` in the `al.reg` autosummary.
- `test_autolens/test_regularization_power.py` mirrors the PyAutoGalaxy composition test.

> **CI note:** green here already. The PyAutoHeart reusable workflow clones each dependency library at the *matching branch if it exists*, and PyAutoArray#512 uses the same branch name, so this PR's CI tested against it. Library-first merge order still applies for `main`'s sake: **merge PyAutoLabs/PyAutoArray#512 first**, otherwise `main` here would reference `ag.reg.AdaptPower` before the symbol exists.

## API Changes

None to `autolens` source — test config, docs and test additions only. The new public symbols are added upstream in PyAutoLabs/PyAutoArray#512 and reach users here as `al.reg.AdaptPower`, `al.reg.AdaptSplitPower`, `al.reg.AdaptSplitZerothPower`, `al.reg.MaternAdaptPowerKernel`.
See full details below.

## Test Plan

- [x] `pytest test_autolens/` — 572 passed, 1 xfailed (with PyAutoArray#512 on `PYTHONPATH`)
- [x] `af.Model(al.reg.AdaptSplitPower)` composes; `power` resolves to the `Constant` value `1.0` and is absent from the prior tuples
- [x] `af.Model(al.reg.AdaptSplit).identifier != af.Model(al.reg.AdaptSplitPower).identifier`
- [x] CI green on all four legs (unittest 3.12 / 3.13 / nojax, docs-build), tested against the PyAutoArray branch

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added

- `test_autolens/config/priors/regularization.yaml` entries for `adapt_power.AdaptPower`, `adapt_split_power.AdaptSplitPower`, `adapt_split_zeroth_power.AdaptSplitZerothPower` and `matern_adapt_power_kernel.MaternAdaptPowerKernel`.
- `docs/api/pixelization.rst` autosummary entries for `AdaptPower` and `AdaptSplitPower`.

### Migration

- Before: `al.reg.AdaptSplit(inner_coefficient=c, outer_coefficient=c)`
- After: `al.reg.AdaptSplitPower(inner_coefficient=c**2, outer_coefficient=c**2)`
- The legacy schemes are untouched, so no migration is required — this is guidance for new work.

</details>

Depends on PyAutoLabs/PyAutoArray#512. Refs PyAutoLabs/PyAutoArray#511.

Generated by the PyAutoLabs agent workflow.
