### PR TITLE
test: Richardson-step regression asserts; theta_for_beta tol 1e-12 (PyAutoGalaxy#591)

### DIFF
--- a/test_autolens/lens/test_multi_plane_cross_validation.py
+++ b/test_autolens/lens/test_multi_plane_cross_validation.py
@@ -1123,25 +1123,22 @@ def test__bug_480_configuration__richardson_hessian_agrees_at_the_intermediate_p
     np.testing.assert_allclose(magnification_hessian, magnification_traced, rtol=1e-6)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="lenscalc_numpy_hessian_step_is_too_coarse: LensCalc._hessian_via_richardson uses a "
-    "hardcoded buffer=0.01 arcsec, which is far too coarse where a ray passes ~4e-4 arcsec from a "
-    "compact deflector's centre. On the PyAutoLens#480 configuration it returns "
-    "[-0.00694, -0.00221, 0.00139, 0.00246] where exact JAX autodiff and the ray-traced Jacobian "
-    "both give [0.04508, 0.01099, -0.08602, -0.01118]: wrong by ~100-120% with a flipped sign on "
-    "all four points. Tracked in PyAutoMind/draft/bug/autogalaxy/"
-    "lenscalc_numpy_hessian_step_is_too_coarse.md. When that is fixed this xfail turns into an "
-    "XPASS and must be removed.",
-)
-def test__bug_480_configuration__numpy_richardson_hessian_step_is_too_coarse():
+def test__bug_480_configuration__numpy_richardson_hessian_agrees_at_the_last_plane():
     """
-    The known, filed defect, pinned rather than tolerated.
+    Regression test for PyAutoGalaxy#591.
 
     ``LensCalc.magnification_2d_via_hessian_from`` at the last plane must agree with the ray-traced
-    Jacobian, which the test above shows reproduces exact autodiff on this configuration. It does
-    not, and this test records exactly by how much. The tolerance is the same 1e-3 used everywhere
-    else in this module: it is not widened to make the disagreement go away.
+    Jacobian, which the test above shows reproduces exact autodiff on this configuration. It did
+    not while ``LensCalc._hessian_via_richardson`` used a hardcoded ``buffer=0.01`` arcsec step:
+    where a ray passes ~4e-4 arcsec from the compact z=1.0 deflector's centre that step straddles
+    the whole deflector, and the NumPy path returned
+    ``[-0.00694, -0.00221, 0.00139, 0.00246]`` against the ``[0.04508, 0.01099, -0.08602,
+    -0.01118]`` that exact JAX autodiff and the ray-traced Jacobian agree on -- wrong by
+    ~100-120% with a flipped sign on all four points. PyAutoGalaxy#591 made the Richardson step
+    adapt per point, and this test now asserts the agreement rather than pinning the defect.
+
+    The tolerance is the same 1e-3 used everywhere else in this module: it was not widened when the
+    test recorded a disagreement, and it is not tightened now that it records an agreement.
     """
     tracer = _bug_480_tracer()
 

--- a/test_autolens/point/fit/test_solved.py
+++ b/test_autolens/point/fit/test_solved.py
@@ -306,7 +306,10 @@ class TestTensorVsScalarWeighting:
                 lambda theta: beta_of_theta(theta) - target_beta,
                 x0=np.array(observed_theta),
                 method="hybr",
-                tol=1.0e-14,
+                # 1e-12, not 1e-14: with the adaptive Hessian (PyAutoGalaxy#591) scipy reports
+                # status 3 ("xtol too small") at residual ~1e-16 - a termination-path artefact,
+                # not a physics change.
+                tol=1.0e-12,
             )
             assert solution.success
             return solution.x


### PR DESCRIPTION
## Summary
Test-only follow-up to PyAutoGalaxy#593 (adaptive Richardson step in `LensCalc`'s NumPy Hessian, fixing PyAutoGalaxy#591). Two changes:

- `test_autolens/lens/test_multi_plane_cross_validation.py` — the strict xfail that pinned the defect on the PyAutoLens#480 fixture now XPASSes; it is converted to a positive regression assertion (renamed `test__bug_480_configuration__numpy_richardson_hessian_agrees_at_the_last_plane`): the NumPy Hessian magnification at the last plane matches the ray-traced Jacobian at rtol 1e-3 (agreement measured at 3.4e-4, the stored reference's own precision), with no `UserWarning`.
- `test_autolens/point/fit/test_solved.py` — `theta_for_beta`'s `scipy.optimize.root(..., tol=1e-14)` relaxed to `1e-12`. With the more accurate Hessian, scipy reported status 3 ("xtol too small") at a residual of ~1e-16 — a termination-path artefact, not a physics change; all three physics assertions in `TestTensorVsScalarWeighting` hold either way. Comment added at the call site.

## API Changes
None — tests only.
See full details below.

## Test Plan
- [x] `pytest test_autolens/lens/test_multi_plane_cross_validation.py -q` → 17 passed (0 xfail), including under `-W error::UserWarning`
- [x] Full `pytest test_autolens -q` → 570 passed, 0 failed against the merged PyAutoGalaxy
- [ ] CI green (checks out PyAutoGalaxy `main`, which now carries #593)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- none

### Added
- none (tests only)

### Migration
- none

</details>

Refs PyAutoGalaxy#591, PyAutoGalaxy#593.

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzKP1RJKhPrtFmsHSm6EEA