### PR TITLE
test: re-pin two knife-edge positions_threshold pins after the exact grid transform (PyAutoArray#519)

### DIFF
--- a/test_autolens/analysis/test_result.py
+++ b/test_autolens/analysis/test_result.py
@@ -211,9 +211,14 @@ def test__positions_threshold_from(analysis_imaging_7x7):
 
     result = res.Result(samples_summary=samples_summary, analysis=analysis_imaging_7x7)
 
-    assert result.positions_threshold_from() == pytest.approx(0.0019501455, 1.0e-4)
+    # Knife-edge pin: the fixture is exactly mirror-symmetric (lens centre and source on
+    # x = 0), so the point solver's branch is decided by sub-ULP tie-breaking; PyAutoArray#519's
+    # exact identity transform at angle 0 selected the other branch (positions_threshold
+    # 0.0019501455 -> 0.0019534291, positions[1].x sign flip, magnitude bit-identical). Values
+    # are the exact-transform branch; a 1e-15 centre nudge flips them. See PyAutoLens#721.
+    assert result.positions_threshold_from() == pytest.approx(0.0019534291, 1.0e-4)
     assert result.positions_threshold_from(factor=5.0) == pytest.approx(
-        0.0097507278035, 1.0e-4
+        0.0097671455155, 1.0e-4
     )
     assert result.positions_threshold_from(minimum_threshold=10.0) == pytest.approx(
         10.0, 1.0e-4
@@ -337,11 +342,16 @@ def test__positions_likelihood_from__mass_centre_radial_distance_min(
 
     assert isinstance(positions_likelihood, al.PositionsLH)
     assert len(positions_likelihood.positions) == 2
+    # Knife-edge pin: the fixture is exactly mirror-symmetric (lens centre and source on
+    # x = 0), so the point solver's branch is decided by sub-ULP tie-breaking; PyAutoArray#519's
+    # exact identity transform at angle 0 selected the other branch (positions_threshold
+    # 0.0019501455 -> 0.0019534291, positions[1].x sign flip, magnitude bit-identical). Values
+    # are the exact-transform branch; a 1e-15 centre nudge flips them. See PyAutoLens#721.
     assert positions_likelihood.positions[0] == pytest.approx(
         (-1.00097656e00, 5.63818622e-04), 1.0e-4
     )
     assert positions_likelihood.positions[1] == pytest.approx(
-        (1.00097656e00, -5.63818622e-04), 1.0e-4
+        (1.00097656e00, 5.63818622e-04), 1.0e-4
     )
 
 


### PR DESCRIPTION
## Summary
Closes #721. Corrective PR for the Heart RED reason `PyAutoLens: CI failure` (main run 33792218906, human-authorized under the corrective-PR exception). Test-only; no library code changes.

Two tests in `test_autolens/analysis/test_result.py` — `test__positions_threshold_from` and `test__positions_likelihood_from__mass_centre_radial_distance_min` — pin a point-solver quantity on an exactly mirror-symmetric configuration (lens centre `(0.1, 0.0)`, source `(0, 0)`, both on `x = 0`, `Isothermal` with `ell_comps=(0,0)`). Bisected across today's library merges with detached scratch worktrees: PyAutoArray#519's rotation-matrix `transform_grid_2d_to_reference_frame` is the **sole mover** (PyAutoGalaxy #599 / #602 / #603 are bit-neutral). The new transform is an exact identity at angle 0 (the old polar form carried 8.9e-16), so the on-axis deflection is now exactly 0 rather than 6.1e-17; the solver hits an exact tie and its tie-break sends both images to the same side. Effects: `positions[1].x` flips sign with a bit-identical magnitude (`5.638186e-04`, a grid-step artefact), and `positions_threshold_from()` moves `0.0019501455607 → 0.0019534291031` (+1.7e-3 relative; `factor=5.0` likewise `0.0097507278 → 0.0097671455`).

The new values are the more accurate branch. The quantity itself is a knife-edge: with the new code a 1e-15 nudge of the centre in x flips the threshold straight back to the old pin, and a 1e-6 nudge moves it by a factor of 86. This PR re-pins both tests to the new values and records the sensitivity and cause in a comment. A follow-up worth filing separately: move the fixture off the symmetry axis (or add a small ellipticity) so the pin is stable rather than branch-selected.

## API Changes
None — test-only change.

## Test Plan
- [x] `test_autolens/analysis/test_result.py` passes against current library `main`s (PyAutoArray `7968d671`+, PyAutoGalaxy `a647aa32`+)
- [x] full `test_autolens` passes locally
- [x] the pre-#519 values reproduce with PyAutoArray `62feb7eb^` (bisect table on issue)

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhnA4pFN2NycuKc8Ni6s2R
