### PR TITLE
docs: drop "also"; AI Assistant note names the paid conversation-assistant routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is called strong gravitational lensing and **PyAutoLens** makes it **simple
 
 ### Human-Readable Documentation and Examples
 
-The following human-readable documentation and examples are also useful for new starters:
+The following human-readable documentation and examples are useful for new starters:
 
 - [The PyAutoLens readthedocs](https://pyautolens.readthedocs.io/en/latest): which includes [an overview of PyAutoLens's core features](https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html).
 - [The introduction Jupyter Notebook on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.8.29.1/start_here.ipynb): try **PyAutoLens** in a web browser (without installation).
@@ -38,7 +38,7 @@ The following human-readable documentation and examples are also useful for new 
 
 The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the [autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.
 
-**The PyAutoLens AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**
+**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
 
 ## Community & Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ This is called strong gravitational lensing and **PyAutoLens** makes it simple t
 
 ## Human-Readable Documentation and Examples
 
-The following human-readable documentation and examples are also useful for new starters:
+The following human-readable documentation and examples are useful for new starters:
 
 - [The PyAutoLens readthedocs](https://pyautolens.readthedocs.io/en/latest): which includes [an overview of PyAutoLens's core features](https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html).
 - [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.8.29.1/start_here.ipynb), where you can try **PyAutoLens** in a web browser (without installation).
@@ -23,7 +23,7 @@ The following human-readable documentation and examples are also useful for new 
 
 The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the [autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.
 
-**The PyAutoLens AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**
+**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
 
 # Strong Gravitational Lensing
 

--- a/docs/overview/overview_1_start_here.md
+++ b/docs/overview/overview_1_start_here.md
@@ -25,7 +25,7 @@ This notebook gives an overview of **PyAutoLens**'s features and API.
 
 The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the [autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.
 
-**The PyAutoLens AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**
+**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
 
 ## Imports
 

--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -15,7 +15,7 @@ This guide begins with two simple questions to help you find the most appropriat
 
 The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the [autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.
 
-**The PyAutoLens AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**
+**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
 
 ## What Scale Lens?
 


### PR DESCRIPTION
## Summary
Follow-up to #723 / PyAutoLabs/autolens_assistant#120. Two wording fixes, no reordering: the human-readable-docs lead sentence drops its now-redundant "also" ("…are useful for new starters:"), and the bold note under the AI Assistant section no longer says conversation agents are unsupported — it now reads: **"The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested."** The paragraph above the note, which lists ChatGPT and the coding agents, is unchanged and now consistent with it.

Part of PyAutoLabs/autolens_assistant#122 (six-repo docs change, PR-open only under a recorded Heart-RED ack — merge is a human decision).

## API Changes
None — documentation only. Files touched:
- `README.md`
- `docs/index.md`
- `docs/overview/overview_1_start_here.md`
- `docs/overview/overview_2_new_user_guide.md`

## Test Plan
- [x] `grep -rn "also useful for new starters"` and `grep -rn "currently only supports AI coding agents"` return nothing
- [ ] docs build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vwajqh36GQMzDcpTRoF5Qj