### PR TITLE
refactor: effective_einstein_radius latent drops its hardcoded seed fan

### DIFF
--- a/autolens/analysis/latent.py
+++ b/autolens/analysis/latent.py
@@ -415,12 +415,15 @@ def effective_einstein_radius(fit, magzero, xp=np):
     """
     Effective Einstein radius via the tangential critical curve.
 
-    JAX path: ``LensCalc.einstein_radius_jit_from(init_guess=fan)``, where
-    ``fan`` is a fixed 4-seed fan at ±1 arcsec from the lens centre — the
-    JIT-compatible variant required because ``ZeroSolver`` (line 1520 of
-    ``autogalaxy/operate/lens_calc.py``) uses ``lax.cond`` /
-    ``lax.while_loop`` early termination that is incompatible with
-    ``jax.vmap`` but fine under ``jax.jit``.
+    JAX path: ``LensCalc.einstein_radius_jit_from()`` with no seed — the
+    JIT-compatible variant, which since PyAutoGalaxy#614 finds its own Newton
+    seed inside the trace (argmin of the tangential eigen value on a coarse
+    grid, ±3 arcsec by default) instead of needing a caller-supplied
+    ``init_guess``. The earlier fixed 4-seed fan at ±1 arcsec from the origin
+    could not converge for off-centre lenses or Einstein radii outside its
+    basin. ``ZeroSolver`` uses ``lax.cond`` / ``lax.while_loop`` early
+    termination that is incompatible with ``jax.vmap`` but fine under
+    ``jax.jit``.
 
     NumPy path: ``LensCalc.einstein_radius_from(grid=fit.dataset.grids.lp)``.
     """
@@ -429,11 +432,7 @@ def effective_einstein_radius(fit, magzero, xp=np):
     try:
         lens_calc = LensCalc.from_mass_obj(fit.tracer)
         if xp is not np and _jax_zero_contour_available():
-            import jax.numpy as jnp
-            init_guess = jnp.array(
-                [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
-            )
-            return lens_calc.einstein_radius_jit_from(init_guess=init_guess)
+            return lens_calc.einstein_radius_jit_from()
         return lens_calc.einstein_radius_from(grid=fit.dataset.grids.lp)
     except (ValueError, AttributeError):
         return xp.nan

--- a/test_autolens/analysis/test_latent.py
+++ b/test_autolens/analysis/test_latent.py
@@ -272,7 +272,7 @@ def test_effective_einstein_radius_calls_lens_calc_numpy_path(monkeypatch):
             calls["grid"] = grid
             return 1.234
 
-        def einstein_radius_jit_from(self, init_guess):
+        def einstein_radius_jit_from(self, init_guess=None):
             calls["init_guess"] = init_guess
             raise AssertionError("numpy path must not use jit_from")
 
@@ -318,7 +318,7 @@ def test_effective_einstein_radius_jax_path_falls_back_to_numpy_when_dep_missing
             calls["grid"] = grid
             return 5.678
 
-        def einstein_radius_jit_from(self, init_guess):
+        def einstein_radius_jit_from(self, init_guess=None):
             raise AssertionError(
                 "jit path must not run when jax_zero_contour is missing"
             )


### PR DESCRIPTION
## Summary

Follow-on to PyAutoLabs/PyAutoGalaxy#615 (issue PyAutoLabs/PyAutoGalaxy#614). `LensCalc.einstein_radius_jit_from` now finds its own Newton seed inside the JIT trace, so the JAX path of the `effective_einstein_radius` latent calls it with no `init_guess`. The fixed 4-seed fan at ±1 arcsec from the origin (`[[1,0],[0,1],[-1,0],[0,-1]]`) is deleted, along with the `jax.numpy` import it needed; the docstring now describes the in-trace seed search. The two test stubs of `einstein_radius_jit_from` mirror the new optional-argument signature.

**Merge order:** after PyAutoGalaxy#615. Against a PyAutoGalaxy without #615 the seedless call raises `TypeError`, which the latent's `except (ValueError, AttributeError)` does not catch. The PyAutoLens unit tests never reach the real jit path (they stub `LensCalc`), so they are green either way; the constraint is the release, and the `pending-release` label carries it.

## API Changes

None — internal changes only. `effective_einstein_radius(fit, magzero, xp=np)` keeps its signature and its numpy path; only how the JAX path seeds the contour trace changes.

## Test Plan

- [x] `test_autolens/analysis/test_latent.py`: 37 passed.
- [ ] After both PRs merge: the Euclid pipeline's `tests/test_compute_latent_variable.py::test_effective_einstein_radius` re-checks the latent value against the Phase B baseline (~2.10 arcsec on the test dataset under `PYAUTO_TEST_MODE=1`).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autolens.analysis.latent.effective_einstein_radius` (JAX path) — calls `LensCalc.einstein_radius_jit_from()` with no seed; the seed is found in-trace by PyAutoGalaxy. Requires PyAutoGalaxy with #615.

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JqpPWfk6nUAqnyv4P5oNM

---
_Generated by [Claude Code](https://claude.ai/code/session_014JqpPWfk6nUAqnyv4P5oNM)_